### PR TITLE
optional changeable export name / fix export name abort

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -160,3 +160,7 @@ msgstr ""
 msgctxt "#30035"
 msgid "Inputstream Addon Settings..."
 msgstr ""
+
+msgctxt "#30036"
+msgid "Always use the original title on export"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -160,3 +160,7 @@ msgstr "ESN (änderbar, wird autom. gesetzt)"
 msgctxt "#30035"
 msgid "Inputstream Addon Settings..."
 msgstr "Inputstream Addon Einstellungen..."
+
+msgctxt "#30036"
+msgid "Always use the original title on export"
+msgstr "Immer den Originaltitel beim Export nutzen"

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -99,12 +99,11 @@ class KodiHelper:
         :obj:`str`
             Title to persist
         """
-        if self.custom_export_name != 'true':
-            dlg = xbmcgui.Dialog()
-            custom_title = dlg.input(heading=self.get_local_string(string_id=30031), defaultt=original_title, type=xbmcgui.INPUT_ALPHANUM) or original_title
-            return custom_title
-        else:
+        if self.custom_export_name == 'true':
             return original_title
+        dlg = xbmcgui.Dialog()
+        custom_title = dlg.input(heading=self.get_local_string(string_id=30031), defaultt=original_title, type=xbmcgui.INPUT_ALPHANUM) or original_title
+        return original_title or custom_title
 
     def show_password_dialog (self):
         """Asks the user for its Netflix password

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -48,6 +48,7 @@ class KodiHelper:
         self.config_path = join(self.base_data_path, 'config')
         self.msl_data_path = xbmc.translatePath('special://profile/addon_data/service.msl').decode('utf-8') + '/'
         self.verb_log = addon.getSetting('logging') == 'true'
+        self.custom_export_name = addon.getSetting('customexportname')
         self.default_fanart = addon.getAddonInfo('fanart')
         self.library = None
         self.setup_memcache()
@@ -98,8 +99,12 @@ class KodiHelper:
         :obj:`str`
             Title to persist
         """
-        dlg = xbmcgui.Dialog()
-        return dlg.input(heading=self.get_local_string(string_id=30031), defaultt=original_title, type=xbmcgui.INPUT_ALPHANUM)
+        if self.custom_export_name != 'true':
+            dlg = xbmcgui.Dialog()
+            custom_title = dlg.input(heading=self.get_local_string(string_id=30031), defaultt=original_title, type=xbmcgui.INPUT_ALPHANUM) or original_title
+            return custom_title
+        else:
+            return original_title
 
     def show_password_dialog (self):
         """Asks the user for its Netflix password

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -9,6 +9,7 @@
   <category label="30025">
     <setting id="enablelibraryfolder" type="bool" label="30026" default="false"/>
     <setting id="customlibraryfolder" type="folder" label="30027" enable="eq(-1,true)" default="special://profile/addon_data/plugin.video.netflix" source="auto" option="writeable" subsetting="true"/>
+    <setting id="customexportname" type="bool" label="30036" default="false"/>
   </category>
   <category label="30023">
     <setting id="enable_dolby_sound" type="bool" label="30033" default="true"/>


### PR DESCRIPTION
Gives users the control via setting to get a dialog to enter export title or use original title given via netflix.
Also it will asign original title if user cancels dialog. (without fix it will write episodes directly in main shows folder)