### PR TITLE
cache search result to fix rerequest seach string after export or remove

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -87,16 +87,16 @@ class KodiHelper:
         :obj:`str`
             Term to search for
         """
-        term = self.get_cached_item(cache_id='search')
+        term = xbmcgui.Window(xbmcgui.getCurrentWindowId()).getProperty('searchstring')
         if len(term) == 0 or term == ' ':
-            term = self.add_cached_item(cache_id='search',contents='')
+            xbmcgui.Window(xbmcgui.getCurrentWindowId()).setProperty('searchstring','')
             dlg = xbmcgui.Dialog()
             term = dlg.input(self.get_local_string(string_id=30003), type=xbmcgui.INPUT_ALPHANUM)
             if len(term) == 0:
                 term = ' '
-            term = self.add_cached_item(cache_id='search',contents=term)
+            xbmcgui.Window(xbmcgui.getCurrentWindowId()).setProperty('searchstring',term)
         else:
-            term = self.get_cached_item(cache_id='search')
+            term = xbmcgui.Window(xbmcgui.getCurrentWindowId()).getProperty('searchstring')
             if len(term) == 0:
                 term = ' '
         return term
@@ -109,7 +109,7 @@ class KodiHelper:
         bool
             Cache cleaned
         """
-        term = self.add_cached_item(cache_id='search',contents='')
+        xbmcgui.Window(xbmcgui.getCurrentWindowId()).setProperty('searchstring','')
         return True
 
     def show_add_to_library_title_dialog (self, original_title):

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -87,11 +87,30 @@ class KodiHelper:
         :obj:`str`
             Term to search for
         """
-        dlg = xbmcgui.Dialog()
-        term = dlg.input(self.get_local_string(string_id=30003), type=xbmcgui.INPUT_ALPHANUM)
-        if len(term) == 0:
-            term = ' '
+        term = self.get_cached_item(cache_id='search')
+        if len(term) == 0 or term == ' ':
+            term = self.add_cached_item(cache_id='search',content='')
+            dlg = xbmcgui.Dialog()
+            term = dlg.input(self.get_local_string(string_id=30003), type=xbmcgui.INPUT_ALPHANUM)
+            if len(term) == 0:
+                term = ' '
+            term = self.add_cached_item(cache_id='search',content=term)
+        else:
+            term = self.get_cached_item(cache_id='search')
+            if len(term) == 0:
+                term = ' '
         return term
+
+    def clean_search_cache (self):
+        """Clean last possible cached search string
+
+        Returns
+        -------
+        bool
+            Cache cleaned
+        """
+        term = self.add_cached_item(cache_id='search',content='')
+        return True
 
     def show_add_to_library_title_dialog (self, original_title):
         """Asks the user for an alternative title for the show/movie that gets exported to the local library

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -89,12 +89,12 @@ class KodiHelper:
         """
         term = self.get_cached_item(cache_id='search')
         if len(term) == 0 or term == ' ':
-            term = self.add_cached_item(cache_id='search',content='')
+            term = self.add_cached_item(cache_id='search',contents='')
             dlg = xbmcgui.Dialog()
             term = dlg.input(self.get_local_string(string_id=30003), type=xbmcgui.INPUT_ALPHANUM)
             if len(term) == 0:
                 term = ' '
-            term = self.add_cached_item(cache_id='search',content=term)
+            term = self.add_cached_item(cache_id='search',contents=term)
         else:
             term = self.get_cached_item(cache_id='search')
             if len(term) == 0:
@@ -109,7 +109,7 @@ class KodiHelper:
         bool
             Cache cleaned
         """
-        term = self.add_cached_item(cache_id='search',content='')
+        term = self.add_cached_item(cache_id='search',contents='')
         return True
 
     def show_add_to_library_title_dialog (self, original_title):

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -76,6 +76,8 @@ class Navigation:
             # show the profiles
             return self.show_profiles()
         elif params['action'] == 'video_lists':
+            # clean possible cached search string
+            self.kodi_helper.clean_search_cache()
             # list lists that contain other lists (starting point with recommendations, search, etc.)
             return self.show_video_lists()
         elif params['action'] == 'video_list':


### PR DESCRIPTION
To prevent from a new input dialog after export or remove to/from db in the list of search results let's cache the search string (and reuse it on refresh which is called after export or remove) until the main menu is reloaded.