### PR TITLE
Make netflix metarequest failsave

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -219,6 +219,18 @@ class KodiHelper:
         dialog.notification(self.get_local_string(string_id=15101), self.get_local_string(string_id=30050))
         return True
 
+    def show_no_metadata_notification (self):
+        """Shows notification that no metadata is available
+
+        Returns
+        -------
+        bool
+            Dialog shown
+        """
+        dialog = xbmcgui.Dialog()
+        dialog.notification(self.get_local_string(string_id=14116), self.get_local_string(string_id=195))
+        return True
+
     def set_setting (self, key, value):
         """Public interface for the addons setSetting method
 

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -133,6 +133,7 @@ class Navigation:
         elif params['action'] == 'user-items' and params['type'] == 'exported':
             # update local db from exported media
             self.library.updatedb_from_exported()
+            self.library.updatedb_from_exported()
             # list exported movies/shows
             return self.kodi_helper.build_video_listing_exported(content=self.library.list_exported_media(),build_url=self.build_url)
         else:
@@ -372,6 +373,9 @@ class Navigation:
             Alternative title (for the folder written to disc)
         """
         metadata = self.call_netflix_service({'method': 'fetch_metadata', 'video_id': video_id})
+        if "error" in metadata:
+            self.kodi_helper.show_no_metadata_notification()
+            return False
         # check for any errors
         if self._is_dirty_response(response=metadata):
             return False
@@ -393,11 +397,14 @@ class Navigation:
         """Removes an item from the local library
 
         Parameters
-        ----------
+        ---------
         video_id : :obj:`str`
             ID of the movie or show
         """
         metadata = self.call_netflix_service({'method': 'fetch_metadata', 'video_id': video_id})
+        if "error" in metadata:
+            self.kodi_helper.show_no_metadata_notification()
+            return False
         # check for any errors
         if self._is_dirty_response(response=metadata):
             return False

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -133,7 +133,6 @@ class Navigation:
         elif params['action'] == 'user-items' and params['type'] == 'exported':
             # update local db from exported media
             self.library.updatedb_from_exported()
-            self.library.updatedb_from_exported()
             # list exported movies/shows
             return self.kodi_helper.build_video_listing_exported(content=self.library.list_exported_media(),build_url=self.build_url)
         else:
@@ -278,7 +277,7 @@ class Navigation:
 
         type : :obj:`str`
             None or 'queue' f.e. when itÂ´s a special video lists
-        
+
         start : :obj:`int`
             Starting point
         """


### PR DESCRIPTION
For example on upcoming shows like star trek discovery without episodes at the moment export fails by broken script caused by failed fetch of metadata. It is now replaced by try and except in combination with a notification.
![screenshot001](https://user-images.githubusercontent.com/761728/30674339-d792fe7c-9e79-11e7-80ec-923cdc6bb107.png)
