### PR TITLE
Enable auto login

### DIFF
--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -228,3 +228,27 @@ msgstr ""
 msgctxt "#30052"
 msgid "Unable to complete the request at this time"
 msgstr ""
+
+msgctxt "#30053"
+msgid "Auto Login"
+msgstr ""
+
+msgctxt "#30054"
+msgid "Enable Auto Login"
+msgstr ""
+
+msgctxt "#30055"
+msgid "Profile"
+msgstr ""
+
+msgctxt "#30056"
+msgid "ID"
+msgstr ""
+
+msgctxt "#30057"
+msgid "Select profile in profile listing -> context menu"
+msgstr ""
+
+msgctxt "#30058"
+msgid "Auto Login enabled!"
+msgstr ""

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -216,3 +216,27 @@ msgstr "Aktualisiere DB"
 msgctxt "#30050"
 msgid "Update successful"
 msgstr "Aktualisierung erfolgreich"
+
+msgctxt "#30053"
+msgid "Auto Login"
+msgstr "Automatisch Anmelden"
+
+msgctxt "#30054"
+msgid "Enable Auto Login"
+msgstr "Aktiviere automatisches Anmelden"
+
+msgctxt "#30055"
+msgid "Profile"
+msgstr "Profil"
+
+msgctxt "#30056"
+msgid "ID"
+msgstr "ID"
+
+msgctxt "#30057"
+msgid "Select profile in profile listing -> context menu"
+msgstr "Wähle Profil in der Übersicht -> Kontextemnü"
+
+msgctxt "#30058"
+msgid "Auto Login enabled!"
+msgstr "Automatische Anmeldung aktiviert!"

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -262,6 +262,18 @@ class KodiHelper:
         dialog = xbmcgui.Dialog()
         dialog.notification(self.get_local_string(string_id=14116), self.get_local_string(string_id=195))
         return True
+        
+    def show_autologin_enabled (self):
+        """Shows notification that auto login is enabled
+
+        Returns
+        -------
+        bool
+            Dialog shown
+        """
+        dialog = xbmcgui.Dialog()
+        dialog.notification(self.get_local_string(string_id=14116), self.get_local_string(string_id=30058))
+        return True
 
     def set_setting (self, key, value):
         """Public interface for the addons setSetting method
@@ -272,6 +284,15 @@ class KodiHelper:
             Setting could be set or not
         """
         return self.get_addon().setSetting(key, value)
+
+    def get_setting (self, key):
+        """Public interface to the addons getSetting method
+
+        Returns
+        -------
+        Returns setting key
+        """
+        return self.get_addon().getSetting(key)
 
     def get_credentials (self):
         """Returns the users stored credentials
@@ -423,6 +444,24 @@ class KodiHelper:
             if view != -1:
                 xbmc.executebuiltin('Container.SetViewMode(%s)' % view)
 
+    def save_autologin_data(self, autologin_user, autologin_id):
+        """Write autologin data to settings
+
+        Parameters
+        ----------
+        autologin_user : :obj:`str`
+            Profile name from netflix
+
+        autologin_id : :obj:`str`
+            Profile id from netflix
+        """
+        self.set_setting ('autologin_user', autologin_user)
+        self.set_setting ('autologin_id', autologin_id)
+        self.set_setting ('autologin_enable', 'True')
+        self.show_autologin_enabled()
+        self.invalidate_memcache()
+        xbmc.executebuiltin('Container.Refresh')
+
     def build_profiles_listing (self, profiles, action, build_url):
         """Builds the profiles list Kodi screen
 
@@ -444,8 +483,10 @@ class KodiHelper:
         """
         for profile in profiles:
             url = build_url({'action': action, 'profile_id': profile['id']})
+            url_save_autologin = build_url({'action': 'save_autologin', 'autologin_id': profile['id'], 'autologin_user': profile['profileName']})
             li = xbmcgui.ListItem(label=profile['profileName'], iconImage=profile['avatar'])
             li.setProperty('fanart_image', self.default_fanart)
+            li.addContextMenuItems([(self.get_local_string(30053), 'RunPlugin('+url_save_autologin+')',)])
             xbmcplugin.addDirectoryItem(handle=self.plugin_handle, url=url, listitem=li, isFolder=True)
             xbmcplugin.addSortMethod(handle=self.plugin_handle, sortMethod=xbmcplugin.SORT_METHOD_LABEL)
         xbmcplugin.endOfDirectory(self.plugin_handle)

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -74,7 +74,15 @@ class Navigation:
             return False
         if 'action' not in params.keys():
             # show the profiles
+            if self.kodi_helper.get_setting ('autologin_enable') == 'true':
+                profile_id = self.kodi_helper.get_setting ('autologin_id')
+                if profile_id != '':
+                    self.call_netflix_service({'method': 'switch_profile', 'profile_id': profile_id})
+                    return self.show_video_lists()
             return self.show_profiles()
+        elif params['action'] == 'save_autologin':
+            # save profile id and name to settings for autologin
+            return self.kodi_helper.save_autologin_data(autologin_id=params['autologin_id'],autologin_user=params['autologin_user'])
         elif params['action'] == 'video_lists':
             # list lists that contain other lists (starting point with recommendations, search, etc.)
             return self.show_video_lists()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -31,4 +31,10 @@
     <setting id="netflix_service_port" value="8001" visible="false"/>
     <setting id="show_update_db" type="bool" default="false" visible="false"/>
   </category>
+  <category label="30053">
+    <setting id="autologin_enable" type="bool" label="30054" default="false"/>
+    <setting id="autologin_user" type="text" label="30055" default="" enable="false" visible="eq(-1,true)" subsetting="true"/>
+    <setting id="autologin_id" type="text" label="30056" default="" enable="false" visible="eq(-2,true)" subsetting="true"/>
+    <setting id="info" type="text" label="30057" default="" enable="false" visible="eq(-3,true)"/>
+  </category>
 </settings>


### PR DESCRIPTION
Give us the option to select a profile for auto login :-)

The profile id is cached as a setting and displayed there. Auto login will be enabled in settings when context menu is used to set profile for auto login  and can be disabled in settings if not longer wanted.

![screenshot001](https://user-images.githubusercontent.com/761728/31048656-2eb7a284-a622-11e7-81fe-b6c5e3760a6e.png)

![screenshot000](https://user-images.githubusercontent.com/761728/31048661-38e6a9e4-a622-11e7-8376-ad2ceefb7a4f.png)
