### PR TITLE
 Automatically mark library items as watched

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -1523,7 +1523,8 @@ class KodiHelper(object):
     def get_show_content_by_id(self, showid, showseason, showepisode):
         showseason = int(showseason)
         showepisode = int(showepisode)
-        props = ["season", "episode", "plot", "fanart", "art", "resume"]
+        props = ["title", "showtitle", "season", "episode", "plot", "fanart",
+                 "art", "resume"]
         query = {
                 "jsonrpc": "2.0",
                 "method": "VideoLibrary.GetEpisodes",
@@ -1545,7 +1546,9 @@ class KodiHelper(object):
                     in_episode = episode['episode'] == showepisode
                     if in_season and in_episode:
                         infos = {'mediatype': 'episode',
-                                 'dbid': episode['episodeid']}
+                                 'dbid': episode['episodeid'],
+                                 'tvshowtitle': episode['showtitle'],
+                                 'title': episode['title']}
                         if episode['resume']['position'] > 0:
                             infos['resume'] = episode['resume']['position']
                         infos.update({'plot': episode['plot'],
@@ -1579,6 +1582,7 @@ class KodiHelper(object):
                 "params": {
                     "movieid": movieid,
                     "properties": [
+                        "title",
                         "genre",
                         "plot",
                         "fanart",
@@ -1595,7 +1599,8 @@ class KodiHelper(object):
             result = json_result.get('result', None)
             if result is not None and 'moviedetails' in result:
                 result = result.get('moviedetails', {})
-                infos = {'mediatype': 'movie', 'dbid': movieid}
+                infos = {'mediatype': 'movie', 'dbid': movieid,
+                         'title': result['title']}
                 if 'resume' in result:
                     infos.update('resume', result['resume'])
                 if 'genre' in result and len(result['genre']) > 0:

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -1540,18 +1540,22 @@ class KodiHelper(object):
                     in_episode = episode['episode'] == showepisode
                     if in_season and in_episode:
                         infos = {'mediatype': 'episode', 'dbid': episode['episodeid']}
-                        if 'resume' in episode and episode['resume']['position'] > 0:
+                        if episode['resume']['position'] > 0:
                             infos['resume'] = episode['resume']['position']
-                        if 'plot' in episode and len(episode['plot']) > 0:
-                            infos.update({
-                                'plot': episode['plot'],
-                                'genre': showid[1]})
+                        infos.update({'plot': episode['plot'],
+                                      'genre': showid[1]}
+                                     if episode.get('plot') else {})
+
                         art = {}
-                        if 'fanart' in episode and len(episode['fanart']) > 0:
-                            art.update({'fanart': episode['fanart']})
-                        if 'art' in episode and len(episode['art']['season.poster']) > 0:
-                            art.update({
-                                'thumb': episode['art']['season.poster']})
+                        art.update({'fanart': episode['fanart']}
+                                   if episode.get('fanart') else {})
+                        if 'art' in episode:
+                            if episode['art'].get('thumb'):
+                                art.update({'thumb': episode['art']['thumb']})
+                            if episode['art'].get('tvshow.poster'):
+                                art.update({'poster': episode['art']['tvshow.poster']})
+                            if episode['art'].get('tvshow.banner'):
+                                art.update({'banner': episode['art']['tvshow.banner']})
                         return infos, art
             return False
         except Exception:

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -46,7 +46,8 @@ class KodiHelper(object):
     turns data into lists of folders and videos"""
 
     TAGGED_WINDOW_ID = 10000
-    PROP_NETFLIX_PLAY = 'is_netflix_play'
+    PROP_NETFLIX_PLAY = 'netflix_playback'
+    PROP_PLAYBACK_INIT = 'initialized'
 
     def __init__(self, plugin_handle=None, base_url=None):
         """
@@ -1140,8 +1141,11 @@ class KodiHelper(object):
             succeeded=True,
             listitem=play_item)
 
-        #set window property to enable recognition of playbacks initiated by this addon
-        xbmcgui.Window(self.TAGGED_WINDOW_ID).setProperty(self.PROP_NETFLIX_PLAY, 'true')
+        # set window property to enable recognition of playbacks
+        xbmcgui.Window(self.TAGGED_WINDOW_ID).setProperty(
+            self.PROP_NETFLIX_PLAY,
+            self.PROP_PLAYBACK_INIT
+        )
 
         return resolved
 

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -1131,12 +1131,12 @@ class KodiHelper(object):
                 details = self.get_movie_content_by_id(movieid=id)
 
             if details is not False:
+                if 'resume' in details[0]:
+                    resume_point = details[0].pop('resume')
+                    play_item.setProperty(
+                        'StartOffset', str(resume_point))
                 play_item.setInfo('video', details[0])
                 play_item.setArt(details[1])
-                resume_point = details[0].get('resume')
-                if resume_point is not None:
-                    play_item.setProperty(
-                        'StartOffset', str(resume_point) + '.0')
 
         resolved = xbmcplugin.setResolvedUrl(
             handle=self.plugin_handle,
@@ -1540,8 +1540,8 @@ class KodiHelper(object):
                     in_episode = episode['episode'] == showepisode
                     if in_season and in_episode:
                         infos = {'mediatype': 'episode', 'dbid': episode['episodeid']}
-                        if 'resume' in episode:
-                            infos.update('resume', episode['resume'])
+                        if 'resume' in episode and episode['resume']['position'] > 0:
+                            infos['resume'] = episode['resume']['position']
                         if 'plot' in episode and len(episode['plot']) > 0:
                             infos.update({
                                 'plot': episode['plot'],

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -45,6 +45,9 @@ class KodiHelper(object):
     Consumes all the configuration data from Kodi as well as
     turns data into lists of folders and videos"""
 
+    TAGGED_WINDOW_ID = 10000
+    PROP_NETFLIX_PLAY = 'is_netflix_play'
+
     def __init__(self, plugin_handle=None, base_url=None):
         """
         Fetches all needed info from Kodi &
@@ -1136,6 +1139,10 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             succeeded=True,
             listitem=play_item)
+
+        #set window property to enable recognition of playbacks initiated by this addon
+        xbmcgui.Window(self.TAGGED_WINDOW_ID).setProperty(self.PROP_NETFLIX_PLAY, 'true')
+
         return resolved
 
     def _generate_art_info(self, entry, li):
@@ -1526,7 +1533,7 @@ class KodiHelper(object):
                     in_season = episode['season'] == showseason
                     in_episode = episode['episode'] == showepisode
                     if in_season and in_episode:
-                        infos = {}
+                        infos = {'mediatype': 'episode', 'dbid': episode['episodeid']}
                         if 'plot' in episode and len(episode['plot']) > 0:
                             infos.update({
                                 'plot': episode['plot'],
@@ -1564,7 +1571,7 @@ class KodiHelper(object):
             result = json_result.get('result', None)
             if result is not None and 'moviedetails' in result:
                 result = result.get('moviedetails', {})
-                infos = {}
+                infos = {'mediatype': 'movie', 'dbid': movieid}
                 if 'genre' in result and len(result['genre']) > 0:
                     infos.update({'genre': json_result['genre']})
                 if 'plot' in result and len(result['plot']) > 0:

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -40,6 +40,11 @@ VIEW_SEASON = 'season'
 VIEW_EPISODE = 'episode'
 
 
+def _update_if_present(source_dict, source_att, target_dict, target_att):
+    if source_dict.get(source_att):
+        target_dict.update({target_att: source_dict[source_att]})
+
+
 class KodiHelper(object):
     """
     Consumes all the configuration data from Kodi as well as
@@ -1539,23 +1544,29 @@ class KodiHelper(object):
                     in_season = episode['season'] == showseason
                     in_episode = episode['episode'] == showepisode
                     if in_season and in_episode:
-                        infos = {'mediatype': 'episode', 'dbid': episode['episodeid']}
+                        infos = {'mediatype': 'episode',
+                                 'dbid': episode['episodeid']}
                         if episode['resume']['position'] > 0:
                             infos['resume'] = episode['resume']['position']
                         infos.update({'plot': episode['plot'],
                                       'genre': showid[1]}
                                      if episode.get('plot') else {})
-
                         art = {}
                         art.update({'fanart': episode['fanart']}
                                    if episode.get('fanart') else {})
                         if 'art' in episode:
-                            if episode['art'].get('thumb'):
-                                art.update({'thumb': episode['art']['thumb']})
-                            if episode['art'].get('tvshow.poster'):
-                                art.update({'poster': episode['art']['tvshow.poster']})
-                            if episode['art'].get('tvshow.banner'):
-                                art.update({'banner': episode['art']['tvshow.banner']})
+                            _update_if_present(source_dict=episode['art'],
+                                               source_att='thumb',
+                                               target_dict=art,
+                                               target_att='thumb')
+                            _update_if_present(source_dict=episode['art'],
+                                               source_att='tvshow.poster',
+                                               target_dict=art,
+                                               target_att='poster')
+                            _update_if_present(source_dict=episode['art'],
+                                               source_att='tvshow.banner',
+                                               target_dict=art,
+                                               target_att='banner')
                         return infos, art
             return False
         except Exception:

--- a/resources/lib/KodiMonitor.py
+++ b/resources/lib/KodiMonitor.py
@@ -117,7 +117,8 @@ class KodiMonitor(xbmc.Monitor):
         if self.is_tracking_playback():
             if self.progress >= 90:
                 new_playcount = self.video_info.get('playcount', 0) + 1
-                self._update_item_details({'playcount': new_playcount})
+                self._update_item_details({'playcount': new_playcount,
+                                           'resume': {'position': 0}})
                 action = 'marking {} as watched.'.format(self.video_info)
             else:
                 action = ('not marking {} as watched, progress too little'

--- a/resources/lib/KodiMonitor.py
+++ b/resources/lib/KodiMonitor.py
@@ -277,12 +277,10 @@ class KodiMonitor(xbmc.Monitor):
         if item is not None:
             if 'tvshowid' in item and item['tvshowid'] > 0:
                 tvshowid = item['tvshowid']
-                params['tvshowid'] = tvshowid
             if 'showtitle' in item and item['showtitle']:
                 showtitle = item['showtitle']
             if 'season' in item and item['season'] > 0:
                 season = item['season']
-                params['season'] = season
             if 'episode' in item and item['episode'] > 0:
                 episode = item['episode']
             if 'label' in item and item['label']:

--- a/resources/lib/KodiMonitor.py
+++ b/resources/lib/KodiMonitor.py
@@ -13,12 +13,94 @@ import xbmcgui
 from resources.lib.utils import noop, log
 
 
-def _get_safe_with_fallback(item, fallback, itemkey='title',
-                            fallbackkey='title', default=''):
+def _get_safe_with_fallback(item, fallback, **kwargs):
+    itemkey = kwargs.get('itemkey', 'title')
+    fallbackkey = kwargs.get('fallbackkey', 'title')
+    default = kwargs.get('default', '')
     try:
         return item.get(itemkey) or fallback.get(fallbackkey)
     except AttributeError:
         return default
+
+
+def _retry(func, max_tries):
+    for _ in range(1, max_tries):
+        xbmc.sleep(3000)
+        retval = func()
+        if retval is not None:
+            return retval
+    return None
+
+
+def _json_rpc(method, params=None):
+    request_data = {'jsonrpc': '2.0', 'method': method, 'id': 1,
+                    'params': params or {}}
+    request = json.dumps(request_data)
+    response = json.loads(unicode(xbmc.executeJSONRPC(request), 'utf-8',
+                                  errors='ignore'))
+    if 'error' in response:
+        raise IOError('JSONRPC-Error {}: {}'
+                      .format(response['error']['code'],
+                              response['error']['message']))
+    return response['result']
+
+
+def _get_active_video_player():
+    return next((player['playerid']
+                 for player in _json_rpc('Player.GetActivePlayers')
+                 if player['type'] == 'video'),
+                None)
+
+
+def _match_episode(item, episode, fallback_data):
+    title = _get_safe_with_fallback(item, fallback_data, itemkey='label')
+    try:
+        matches_show = (item.get('tvshowid') == episode['tvshowid'] or
+                        item.get('showtitle') == episode['showtitle'])
+        matches_season = item.get('season') == episode['season']
+        matches_episode = item.get('episode') == episode['episode']
+        matches_explicitly = (matches_show and matches_season and
+                              matches_episode)
+    except AttributeError:
+        matches_explicitly = False
+
+    episode_meta = 'S%02dE%02d' % (episode['season'],
+                                   episode['episode'])
+    matches_meta = (episode['showtitle'] in title and
+                    episode_meta in title)
+    return matches_explicitly or matches_meta
+
+
+def _guess_episode(item, fallback_data):
+    resp = _json_rpc('VideoLibrary.GetEpisodes',
+                     {'properties': ['playcount', 'tvshowid',
+                                     'showtitle', 'season',
+                                     'episode']})
+    return next(({'dbtype': 'episode', 'dbid': episode['episodeid'],
+                  'playcount': episode['playcount']}
+                 for episode in resp.get('episodes', [])
+                 if _match_episode(item, episode, fallback_data)),
+                None)
+
+
+def _match_movie(item, movie, fallback_data):
+    title = _get_safe_with_fallback(item, fallback_data)
+    movie_meta = '%s (%d)' % (movie['label'], movie['year'])
+    return movie_meta == title or movie['label'] in title
+
+
+def _guess_movie(item, fallback_data):
+    params = {'properties': ['playcount', 'year', 'title']}
+    try:
+        params['filter'] = {'year': item['year']}
+    except (TypeError, KeyError):
+        pass
+    resp = _json_rpc('VideoLibrary.GetMovies', params)
+    return next(({'dbtype': 'movie', 'dbid': movie['movieid'],
+                  'playcount': movie['playcount']}
+                 for movie in resp.get('movies', [])
+                 if _match_movie(item, movie, fallback_data)),
+                None)
 
 
 class KodiMonitor(xbmc.Monitor):
@@ -60,9 +142,9 @@ class KodiMonitor(xbmc.Monitor):
         if not self.is_tracking_playback():
             return
 
-        player_id = self._get_active_video_player()
+        player_id = _get_active_video_player()
         try:
-            progress = self._json_rpc('Player.GetProperties', {
+            progress = _json_rpc('Player.GetProperties', {
                 'playerid': player_id,
                 'properties': ['percentage', 'time']
             })
@@ -88,11 +170,7 @@ class KodiMonitor(xbmc.Monitor):
 
     @log
     def _on_playback_started(self, item):
-        for _ in range(1, 5):
-            xbmc.sleep(3000)
-            player_id = self._get_active_video_player()
-            if player_id is not None:
-                break
+        player_id = _retry(_get_active_video_player, 5)
 
         if player_id is not None and self.is_initialized_playback():
             self.video_info = self._get_video_info(player_id, item)
@@ -107,10 +185,10 @@ class KodiMonitor(xbmc.Monitor):
             # we overwrite it with an arbitrary value
             xbmcgui.Window(self.kodi_helper.TAGGED_WINDOW_ID).setProperty(
                 self.kodi_helper.PROP_NETFLIX_PLAY, 'notnetflix')
-            reason = ('Playback not initiated by netflix plugin'
-                      if self.is_initialized_playback() else
-                      'Unable to obtain active video player')
-            self.log('Not tracking playback: {}'.format(reason))
+            self.log('Not tracking playback: {}'
+                     .format('Playback not initiated by netflix plugin'
+                             if self.is_initialized_playback() else
+                             'Unable to obtain active video player'))
 
     @log
     def _on_playback_stopped(self):
@@ -130,99 +208,40 @@ class KodiMonitor(xbmc.Monitor):
         self.video_info = None
         self.progress = 0
 
-    def _get_active_video_player(self):
-        return next((player['playerid']
-                     for player in self._json_rpc('Player.GetActivePlayers')
-                     if player['type'] == 'video'), None)
-
     @log
     def _get_video_info(self, player_id, fallback_data):
-        info = self._json_rpc('Player.GetItem',
-                              {
-                                  'playerid': player_id,
-                                  'properties': ['playcount', 'title', 'year',
-                                                 'tvshowid', 'showtitle',
-                                                 'season', 'episode']
-                              }).get('item', {})
+        info = _json_rpc('Player.GetItem',
+                         {
+                             'playerid': player_id,
+                             'properties': ['playcount', 'title', 'year',
+                                            'tvshowid', 'showtitle',
+                                            'season', 'episode']
+                         }).get('item', {})
         try:
             return {'dbtype': info['type'], 'dbid': info['id'],
                     'playcount': info.get('playcount', 0)}
         except KeyError:
             video_info = (self._guess_episode(info, fallback_data) or
                           self._guess_movie(info, fallback_data))
-            if video_info is not None:
-                self.log('Obtained video info by guessing: {}'
-                         .format(video_info))
+            if video_info is None:
+                self.log('Unable to obtain video info (fallback_data={})'
+                         .format(fallback_data),
+                         xbmc.LOGERROR)
             else:
-                self.log('Unable to obtain video info.', xbmc.LOGERROR)
+                self.log('Obtained video info by guessing ({})'
+                         .format(video_info),
+                         xbmc.LOGWARNING)
             return video_info
 
     @log
-    def _guess_episode(self, item, fallback_data):
-        title = _get_safe_with_fallback(item, fallback_data, itemkey='label')
-        resp = self._json_rpc('VideoLibrary.GetEpisodes',
-                              {'properties': ['playcount', 'tvshowid',
-                                              'showtitle', 'season',
-                                              'episode']})
-        for episode in resp.get('episodes', []):
-            try:
-                matches_show = (item.get('tvshowid') == episode['tvshowid'] or
-                                item.get('showtitle') == episode['showtitle'])
-                matches_season = item.get('season') == episode['season']
-                matches_episode = item.get('episode') == episode['episode']
-                matches_explicitly = (matches_show and matches_season and
-                                      matches_episode)
-            except AttributeError:
-                matches_explicitly = False
-
-            episode_meta = 'S%02dE%02d' % (episode['season'],
-                                           episode['episode'])
-            matches_meta = (episode['showtitle'] in title and
-                            episode_meta in title)
-
-            if matches_explicitly or matches_meta:
-                return {'dbtype': 'episode', 'dbid': episode['episodeid'],
-                        'playcount': episode['playcount']}
-        return None
-
-    @log
-    def _guess_movie(self, item, fallback_data):
-        title = _get_safe_with_fallback(item, fallback_data)
-        params = {'properties': ['playcount', 'year', 'title']}
-        try:
-            params['filter'] = {'year': item['year']}
-        except (TypeError, KeyError):
-            pass
-        resp = self._json_rpc('VideoLibrary.GetMovies', params)
-        for movie in resp.get('movies', []):
-            movie_meta = '%s (%d)' % (movie['label'], movie['year'])
-            if movie_meta == title or movie['label'] in title:
-                return {'dbtype': 'movie', 'dbid': movie['movieid'],
-                        'playcount': movie['playcount']}
-        return None
-
     def _update_item_details(self, properties):
         method = ('VideoLibrary.Set{}Details'
                   .format(self.video_info['dbtype'].capitalize()))
         params = {'{}id'.format(self.video_info['dbtype']):
                   self.video_info['dbid']}
         params.update(properties)
-        self._json_rpc(method, params)
+        _json_rpc(method, params)
 
     def _is_playback_status(self, status):
         return xbmcgui.Window(self.kodi_helper.TAGGED_WINDOW_ID).getProperty(
             self.kodi_helper.PROP_NETFLIX_PLAY) == status
-
-    def _json_rpc(self, method, params=None):
-        request_data = {'jsonrpc': '2.0', 'method': method, 'id': 1,
-                        'params': params or {}}
-        request = json.dumps(request_data)
-        self.log(u'Sending request: {}'.format(request))
-        response = json.loads(unicode(xbmc.executeJSONRPC(request), 'utf-8',
-                                      errors='ignore'))
-        self.log(u'Received response: {}'.format(response))
-        if 'error' in response:
-            raise IOError('JSONRPC-Error {}: {}'
-                          .format(response['error']['code'],
-                                  response['error']['message']))
-        return response['result']

--- a/resources/lib/KodiMonitor.py
+++ b/resources/lib/KodiMonitor.py
@@ -1,0 +1,203 @@
+# pylint: skip-file
+# -*- coding: utf-8 -*-
+# Module: KodiHelper
+# Created on: 13.01.2017
+
+import xbmc
+import xbmcgui
+import json
+
+
+class KodiMonitor(xbmc.Monitor):
+
+    def __init__(self, kodi_helper):
+        super(KodiMonitor, self).__init__()
+        self.kodi_helper = kodi_helper
+        self.video_info = None
+        self.progress = 0
+
+    def update_playback_progress(self):
+        if self.video_info is not None:
+            player_id = self.get_active_video_player()
+
+            if player_id is not None:
+                method = 'Player.GetProperties'
+                params = {
+                    'playerid': player_id,
+                    'properties': ['percentage']
+                }
+
+                response = self.json_rpc(method, params)
+
+                if 'result' in response:
+                    self.progress = response['result']['percentage']
+                    self.kodi_helper.log(
+                        msg='Current playback progress is {}%'.format(
+                            self.progress)
+                    )
+                else:
+                    self.kodi_helper.log(
+                        msg='Could not update playback progress'
+                    )
+
+    def onNotification(self, sender, method, data):
+        data = json.loads(unicode(data, 'utf-8', errors='ignore'))
+
+        if method == 'Player.OnPlay':
+            self.on_playback_started(data.get('item', None))
+        elif method == 'Player.OnStop':
+            self.on_playback_stopped(data['end'])
+
+    def on_playback_started(self, item):
+        self.kodi_helper.log(
+            msg='Playback started, waiting for player - item: {}'.format(item)
+        )
+
+        # wait for player to start playing video
+        xbmc.sleep(7500)
+        player_id = self.get_active_video_player()
+
+        if self.is_netflix_play() and player_id is not None:
+            self.video_info = self.get_video_info(player_id, item)
+            self.progress = 0
+        else:
+            self.kodi_helper.log(
+                msg='Playback is not from Netflix or it suddenly stopped'
+            )
+
+    def on_playback_stopped(self, ended):
+        if self.video_info is not None and self.is_netflix_play():
+            self.kodi_helper.log(msg='Netflix playback stopped')
+
+            if self.progress >= 90:
+                self.increment_playcount(
+                    self.video_info['dbtype'],
+                    self.video_info['dbid'],
+                    self.video_info['playcount']
+                )
+            else:
+                self.kodi_helper.log(
+                    msg='Progress insufficient, not marking as watched'
+                )
+        else:
+            self.kodi_helper.log(msg='Playback was not from Netflix')
+
+        self.video_info = None
+        self.progress = 0
+
+    def increment_playcount(self, dbtype, dbid, playcount=0):
+        new_playcount = playcount + 1
+
+        self.kodi_helper.log(
+            msg='Incrementing playcount of {} with dbid {} to {}'.format(
+                dbtype, dbid, new_playcount),
+            level=xbmc.LOGNOTICE
+        )
+
+        method = 'VideoLibrary.Set{}Details'.format(dbtype.capitalize())
+        params = {
+            '{}id'.format(dbtype): dbid,
+            'playcount': new_playcount
+        }
+
+        return self.json_rpc(method, params)
+
+    def get_active_video_player(self):
+        method = 'Player.GetActivePlayers'
+        resp = self.json_rpc(method)
+
+        if 'result' in resp:
+            for player in resp['result']:
+                if player['type'] == 'video':
+                    return player['playerid']
+
+        return None
+
+    def get_video_info(self, player_id, fallback_data):
+        method = 'Player.GetItem'
+        params = {
+            'playerid': player_id,
+            'properties': [
+                'playcount',
+                'title',
+                'year',
+                'showtitle',
+                'season',
+                'episode'
+            ]
+        }
+
+        resp = self.json_rpc(method, params)
+
+        if 'result' in resp and 'item' in resp['result']:
+            item = resp['result']['item']
+
+            self.kodi_helper.log(
+                msg=u'Got info from player: {}'.format(item)
+            )
+
+            dbid = item.get('id', None)
+            dbtype = item.get('type', None)
+
+            if dbtype is not None and dbid is not None:
+                playcount = item['playcount']
+                video_info = {
+                    'dbtype': dbtype,
+                    'dbid': dbid,
+                    'playcount': playcount
+                }
+                self.kodi_helper.log(
+                    msg='Found video info from player: {}'.format(video_info)
+                )
+
+                if video_info['dbtype'] in ['episode', 'movie']:
+                    return video_info
+                else:
+                    self.kodi_helper.log(msg='Not playing an episode or movie')
+                    return None
+
+        video_info = self.get_video_info_fallback(fallback_data)
+
+        if video_info is not None:
+            self.kodi_helper.log(
+                msg='Found video info by fallback: {}'.format(video_info)
+            )
+        else:
+            self.kodi_helper.log(
+                msg='Could not get video info',
+                level=xbmc.LOGERROR
+            )
+
+        return video_info
+
+    def get_video_info_fallback(self, data):
+        self.kodi_helper.log(
+            msg='Using fallback lookup method for video info (BAD)',
+            level=xbmc.LOGWARNING
+        )
+        return None
+
+    def is_netflix_play(self):
+        return xbmcgui.Window(self.kodi_helper.TAGGED_WINDOW_ID).getProperty(
+            self.kodi_helper.PROP_NETFLIX_PLAY
+        ) is not None
+
+    def json_rpc(self, method, params=None):
+        req = {
+            'jsonrpc': '2.0',
+            'method': method,
+            'id': 1,
+            'params': params or {}
+        }
+
+        jsonrequest = json.dumps(req)
+        self.kodi_helper.log(msg='Sending request: {}'.format(jsonrequest))
+
+        jsonresponse = unicode(
+            xbmc.executeJSONRPC(jsonrequest),
+            'utf-8',
+            errors='ignore'
+        )
+        self.kodi_helper.log(msg='Received response: {}'.format(jsonresponse))
+
+        return json.loads(jsonresponse)

--- a/service.py
+++ b/service.py
@@ -10,8 +10,8 @@
 import threading
 import socket
 from SocketServer import TCPServer
-from xbmc import Monitor
 from resources.lib.KodiHelper import KodiHelper
+from resources.lib.KodiMonitor import KodiMonitor
 from resources.lib.MSLHttpRequestHandler import MSLHttpRequestHandler
 from resources.lib.NetflixHttpRequestHandler import NetflixHttpRequestHandler
 
@@ -56,7 +56,7 @@ NS_SERVER.server_activate()
 NS_SERVER.timeout = 1
 
 if __name__ == '__main__':
-    MONITOR = Monitor()
+    MONITOR = KodiMonitor(KODI_HELPER)
 
     # start thread for MLS servie
     MSL_THREAD = threading.Thread(target=MSL_SERVER.serve_forever)
@@ -70,6 +70,8 @@ if __name__ == '__main__':
 
     # kill the services if kodi monitor tells us to
     while not MONITOR.abortRequested():
+        MONITOR.update_playback_progress()
+
         if MONITOR.waitForAbort(5):
             MSL_SERVER.shutdown()
             NS_SERVER.shutdown()

--- a/service.py
+++ b/service.py
@@ -56,7 +56,7 @@ NS_SERVER.server_activate()
 NS_SERVER.timeout = 1
 
 if __name__ == '__main__':
-    MONITOR = KodiMonitor(KODI_HELPER)
+    MONITOR = KodiMonitor(KODI_HELPER, KODI_HELPER.log)
 
     # start thread for MLS servie
     MSL_THREAD = threading.Thread(target=MSL_SERVER.serve_forever)


### PR DESCRIPTION
This fixes #236. It tracks playback progress of streams being played through the addon and marks the associated library items - if any - as watched after playback (if progress is >= 90%).

If the database ID of playbacks is not added to the info labels (due to #283), accuracy is not always 100% as it uses a more inaccurate fallback method to lookup database IDs. It comes pretty close though, I haven't had any mismatches in my tests.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?