### PR TITLE
Add metadata fetching for individual episodes when exporting to library

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -1232,7 +1232,8 @@ class KodiHelper(object):
         li.setInfo('video', infos)
         if li_infos.get('is_playable'):
             li.setProperty('IsPlayable', 'true')
-        li.addStreamInfo('video', li_infos['quality'])
+        if 'quality' in li_infos:
+            li.addStreamInfo('video', li_infos['quality'])
         return li, infos
 
     def _generate_entry_info(self, entry, base_info={}):

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -584,7 +584,6 @@ class Navigation(object):
                     if episode_list:
                         for episode in episode_list.itervalues():
                             episode['tvshowtitle'] = video['title']
-                            self.log(msg='EPISODE: {}'.format(episode))
                             self.kodi_helper._generate_art_info(entry=episode)
                             self.kodi_helper._generate_entry_info(
                                 entry=episode,

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -570,6 +570,25 @@ class Navigation(object):
             if video['type'] == 'show':
                 episodes = []
                 for season in video['seasons']:
+                    user_data = (
+                        self._check_response(
+                            self.call_netflix_service(
+                                {'method': 'get_user_data'})))
+                    episode_list = (
+                        self._check_response(
+                            self.call_netflix_service({
+                                'method': 'fetch_episodes_by_season',
+                                'season_id': season['id'],
+                                'guid': user_data['guid'],
+                                'cache': True})))
+                    if episode_list:
+                        for episode in episode_list.itervalues():
+                            episode['tvshowtitle'] = video['title']
+                            self.log(msg='EPISODE: {}'.format(episode))
+                            self.kodi_helper._generate_art_info(entry=episode)
+                            self.kodi_helper._generate_entry_info(
+                                entry=episode,
+                                base_info={'mediatype': 'episode'})
                     for episode in season['episodes']:
                         episodes.append({
                             'season': season['seq'],


### PR DESCRIPTION
This fixes #283. Metadata for individual episodes are downloaded and written to disk when a show/season is exported to the library. Uses the same code that is used when browsing an episode listing. No changes are required for movies, because they are always browsed in a listing before being added to the library.

This is required for #293 to work reliably. Merging both should make the library integration almost perfect (bookmarks/resume still being an issue due to Kodi's funny handling of startOffset property when returned from setResolvedUrl() method).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
