### PR TITLE
Separate CryptoSessions from MSL core / implement widevine cryptoSess…

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -8,7 +8,7 @@
 
 
 import sys
-from resources.lib.KodiHelper import KodiHelper
+from resources.lib.NetflixCommon import NetflixCommon
 from resources.lib.Navigation import Navigation
 from resources.lib.Library import Library
 
@@ -19,24 +19,19 @@ BASE_URL = sys.argv[0]
 REQUEST_PARAMS = sys.argv[2][1:]
 
 # init plugin libs
-KODI_HELPER = KodiHelper(
+NETFLIX_COMMON = NetflixCommon(
     plugin_handle=PLUGIN_HANDLE,
     base_url=BASE_URL
 )
-LIBRARY = Library(
-    root_folder=KODI_HELPER.base_data_path,
-    library_settings=KODI_HELPER.get_custom_library_settings(),
-    log_fn=KODI_HELPER.log
-)
+
+LIBRARY = Library(nx_common=NETFLIX_COMMON)
+
 NAVIGATION = Navigation(
-    kodi_helper=KODI_HELPER,
+    nx_common=NETFLIX_COMMON,
     library=LIBRARY,
-    base_url=BASE_URL,
-    log_fn=KODI_HELPER.log
 )
-KODI_HELPER.set_library(library=LIBRARY)
 
 if __name__ == '__main__':
     # Call the router function and pass the plugin call parameters to it.
-    KODI_HELPER.log('Started (Version ' + KODI_HELPER.version + ')')
+    NETFLIX_COMMON.log('Started (Version ' + NETFLIX_COMMON.version + ')')
     NAVIGATION.router(paramstring=REQUEST_PARAMS)

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -10,18 +10,13 @@ import hashlib
 from os import remove
 from uuid import uuid4
 from urllib import urlencode
-from Cryptodome import Random
-from os.path import join, isfile
-from Cryptodome.Cipher import AES
-from Cryptodome.Util import Padding
 import xbmc
 import xbmcgui
 import xbmcplugin
 import inputstreamhelper
 from xbmcaddon import Addon
-from resources.lib.MSL import MSL
 from resources.lib.kodi.Dialogs import Dialogs
-from utils import get_user_agent, uniq_id
+from utils import get_user_agent
 from UniversalAnalytics import Tracker
 try:
     import cPickle as pickle
@@ -62,243 +57,39 @@ class KodiHelper(object):
     PROP_NETFLIX_PLAY = 'netflix_playback'
     PROP_PLAYBACK_INIT = 'initialized'
 
-    def __init__(self, plugin_handle=None, base_url=None):
+    def __init__(self, plugin_handle, base_url, library):
         """
-        Fetches all needed info from Kodi &
-        configures the baseline of the plugin
-
-        Parameters
-        ----------
-        plugin_handle : :obj:`int`
-            Plugin handle
-
-        base_url : :obj:`str`
-            Plugin base url
+        Provides helpers for addon side (not service side)
         """
-        addon = self.get_addon()
-        raw_data_path = 'special://profile/addon_data/service.msl'
-        data_path = xbmc.translatePath(raw_data_path)
+        self.addon = Addon()
         self.plugin_handle = plugin_handle
         self.base_url = base_url
-        self.plugin = addon.getAddonInfo('name')
-        self.version = addon.getAddonInfo('version')
-        self.base_data_path = xbmc.translatePath(addon.getAddonInfo('profile'))
-        self.home_path = xbmc.translatePath('special://home')
-        self.plugin_path = addon.getAddonInfo('path')
-        self.cookie_path = self.base_data_path + 'COOKIE'
-        self.data_path = self.base_data_path + 'DATA'
-        self.config_path = join(self.base_data_path, 'config')
-        self.msl_data_path = data_path.decode('utf-8') + '/'
-        self.verb_log = addon.getSetting('logging') == 'true'
-        self.custom_export_name = addon.getSetting('customexportname')
-        self.show_update_db = addon.getSetting('show_update_db')
-        self.default_fanart = addon.getAddonInfo('fanart')
-        self.icon = addon.getAddonInfo('icon')
-        self.bs = 32
-        self.crypt_key = uniq_id()
-        self.library = None
+        self.library = library
+        self.custom_export_name = self.addon.getSetting('customexportname')
+        self.show_update_db = self.addon.getSetting('show_update_db')
+        self.default_fanart = self.addon.getAddonInfo('fanart')
         self.setup_memcache()
         self.dialogs = Dialogs(
             get_local_string=self.get_local_string,
             custom_export_name=self.custom_export_name)
 
-    def get_addon(self):
-        """Returns a fresh addon instance"""
-        return Addon()
-
-    def check_folder_path(self, path):
-        """
-        Check if folderpath ends with path delimator
-        If not correct it (makes sure xbmcvfs.exists is working correct)
-        """
-        if isinstance(path, unicode):
-            check = path.encode('ascii', 'ignore')
-            if '/' in check and not str(check).endswith('/'):
-                end = u'/'
-                path = path + end
-                return path
-            if '\\' in check and not str(check).endswith('\\'):
-                end = u'\\'
-                path = path + end
-                return path
-        if '/' in path and not str(path).endswith('/'):
-            path = path + '/'
-            return path
-        if '\\' in path and not str(path).endswith('\\'):
-            path = path + '\\'
-            return path
-
     def refresh(self):
         """Refresh the current list"""
         return xbmc.executebuiltin('Container.Refresh')
 
-    def set_setting(self, key, value):
-        """Public interface for the addons setSetting method
-
-        Returns
-        -------
-        bool
-            Setting could be set or not
-        """
-        return self.get_addon().setSetting(key, value)
-
-    def get_setting(self, key):
-        """Public interface to the addons getSetting method
-
-        Returns
-        -------
-        Returns setting key
-        """
-        return self.get_addon().getSetting(key)
+    def get_addon(self):
+        """Return the current addon instance"""
+        return self.addon
 
     def toggle_adult_pin(self):
         """Toggles the adult pin setting"""
-        addon = self.get_addon()
         adultpin_enabled = False
-        raw_adultpin_enabled = addon.getSetting('adultpin_enable')
+        raw_adultpin_enabled = self.addon.getSetting('adultpin_enable')
         if raw_adultpin_enabled == 'true' or raw_adultpin_enabled == 'True':
             adultpin_enabled = True
         if adultpin_enabled is False:
-            return addon.setSetting('adultpin_enable', 'True')
-        return addon.setSetting('adultpin_enable', 'False')
-
-    def get_credentials(self):
-        """Returns the users stored credentials
-
-        Returns
-        -------
-        :obj:`dict` of :obj:`str`
-            The users stored account data
-        """
-        addon = self.get_addon()
-        email = addon.getSetting('email')
-        password = addon.getSetting('password')
-
-        # soft migration for existing credentials
-        # base64 can't contain `@` chars
-        if '@' in email:
-            addon.setSetting('email', self.encode(raw=email))
-            addon.setSetting('password', self.encode(raw=password))
-            return {
-                'email': self.get_addon().getSetting('email'),
-                'password': self.get_addon().getSetting('password')
-            }
-
-        # if everything is fine, we decode the values
-        if '' != email or '' != password:
-            return {
-                'email': self.decode(enc=email),
-                'password': self.decode(enc=password)
-            }
-
-        # if email is empty, we return an empty map
-        return {
-            'email': '',
-            'password': ''
-        }
-
-    def encode(self, raw):
-        """
-        Encodes data
-
-        :param data: Data to be encoded
-        :type data: str
-        :returns:  string -- Encoded data
-        """
-        raw = Padding.pad(data_to_pad=raw, block_size=self.bs)
-        iv = Random.new().read(AES.block_size)
-        cipher = AES.new(self.crypt_key, AES.MODE_CBC, iv)
-        return base64.b64encode(iv + cipher.encrypt(raw))
-
-    def decode(self, enc):
-        """
-        Decodes data
-
-        :param data: Data to be decoded
-        :type data: str
-        :returns:  string -- Decoded data
-        """
-        enc = base64.b64decode(enc)
-        iv = enc[:AES.block_size]
-        cipher = AES.new(self.crypt_key, AES.MODE_CBC, iv)
-        decoded = Padding.unpad(
-            padded_data=cipher.decrypt(enc[AES.block_size:]),
-            block_size=self.bs).decode('utf-8')
-        return decoded
-
-    def get_esn(self):
-        """
-        Returns the esn from settings
-        """
-        return self.get_addon().getSetting('esn')
-
-    def set_esn(self, esn):
-        """
-        Returns the esn from settings
-        """
-        stored_esn = self.get_esn()
-        if not stored_esn and esn:
-            self.set_setting('esn', esn)
-            self.delete_manifest_data()
-            return esn
-        return stored_esn
-
-    def delete_manifest_data(self):
-        if isfile(self.msl_data_path + 'msl_data.json'):
-            remove(self.msl_data_path + 'msl_data.json')
-        if isfile(self.msl_data_path + 'manifest.json'):
-            remove(self.msl_data_path + 'manifest.json')
-        msl = MSL(kodi_helper=self)
-        msl.perform_key_handshake()
-        msl.save_msl_data()
-
-    def get_dolby_setting(self):
-        """
-        Returns if the dolby sound is enabled
-        :return: bool - Dolby Sourrind profile setting is enabled
-        """
-        use_dolby = False
-        setting = self.get_addon().getSetting('enable_dolby_sound')
-        if setting == 'true' or setting == 'True':
-            use_dolby = True
-        return use_dolby
-
-    def use_hevc(self):
-        """
-        Checks if HEVC profiles should be used
-        :return: bool - HEVC profile setting is enabled
-        """
-        use_hevc = False
-        setting = self.get_addon().getSetting('enable_hevc_profiles')
-        if setting == 'true' or setting == 'True':
-            use_hevc = True
-        return use_hevc
-
-    def get_custom_library_settings(self):
-        """Returns the settings in regards to the custom library folder(s)
-
-        Returns
-        -------
-        :obj:`dict` of :obj:`str`
-            The users library settings
-        """
-        addon = self.get_addon()
-        return {
-            'enablelibraryfolder': addon.getSetting('enablelibraryfolder'),
-            'customlibraryfolder': addon.getSetting('customlibraryfolder')
-        }
-
-    def get_ssl_verification_setting(self):
-        """
-        Returns the setting that describes if we should
-        verify the ssl transport when loading data
-
-        Returns
-        -------
-        bool
-            Verify or not
-        """
-        return self.get_addon().getSetting('ssl_verification') == 'true'
+            return self.addon.setSetting('adultpin_enable', 'True')
+        return self.addon.setSetting('adultpin_enable', 'False')
 
     def set_main_menu_selection(self, type):
         """Persist the chosen main menu entry in memory
@@ -398,9 +189,9 @@ class KodiHelper(object):
             (folder, movie, show, season, episode, login, exported)
 
         """
-        custom_view = self.get_addon().getSetting('customview')
+        custom_view = self.addon.getSetting('customview')
         if custom_view == 'true':
-            view = int(self.get_addon().getSetting('viewmode' + content))
+            view = int(self.addon.getSetting('viewmode' + content))
             if view != -1:
                 xbmc.executebuiltin('Container.SetViewMode(%s)' % view)
 
@@ -1091,14 +882,11 @@ class KodiHelper(object):
         self.set_custom_view(VIEW_EPISODE)
         return True
 
-    def play_item(self, esn, video_id, start_offset=-1, infoLabels={}):
+    def play_item(self, video_id, start_offset=-1, infoLabels={}):
         """Plays a video
 
         Parameters
         ----------
-        esn : :obj:`str`
-            ESN needed for Widevine/Inputstream
-
         video_id : :obj:`str`
             ID of the video that should be played
 
@@ -1113,8 +901,7 @@ class KodiHelper(object):
         bool
             List could be build
         """
-        self.set_esn(esn)
-        addon = self.get_addon()
+        addon = self.addon
         is_helper = inputstreamhelper.Helper('mpd', drm='widevine')
         if not is_helper.check_inputstream():
             return False
@@ -1122,14 +909,13 @@ class KodiHelper(object):
         # track play event
         self.track_event('playVideo')
 
-        # check esn in settings
-        settings_esn = str(addon.getSetting('esn'))
-        if len(settings_esn) == 0:
-            addon.setSetting('esn', str(esn))
-
         # inputstream addon properties
         port = str(addon.getSetting('msl_service_port'))
         msl_service_url = 'http://localhost:' + port
+        msl_manifest_url = msl_service_url + '/manifest?id=' + video_id
+        msl_manifest_url += '&dolby=' + self.addon.getSetting('enable_dolby_sound')
+        msl_manifest_url += '&hevc=' +  self.addon.getSetting('enable_hevc_profiles')
+
         play_item = xbmcgui.ListItem(
             path=msl_service_url + '/manifest?id=' + video_id)
         play_item.setContentLookup(False)
@@ -1292,7 +1078,7 @@ class KodiHelper(object):
             'season': '',
             'title': '',
             'tvshowtitle': '',
-            'mediatype': '',
+            'mediatype': 'movie',
             'playcount': '',
             'episode': '',
             'year': ''
@@ -1431,21 +1217,6 @@ class KodiHelper(object):
         li.addContextMenuItems(items)
         return li
 
-    def log(self, msg, level=xbmc.LOGDEBUG):
-        """Adds a log entry to the Kodi log
-
-        Parameters
-        ----------
-        msg : :obj:`str`
-            Entry that should be turned into a list item
-
-        level : :obj:`int`
-            Kodi log level
-        """
-        if isinstance(msg, unicode):
-            msg = msg.encode('utf-8')
-        xbmc.log('[%s] %s' % (self.plugin, msg.__str__()), level)
-
     def get_local_string(self, string_id):
         """Returns the localized version of a string
 
@@ -1459,7 +1230,7 @@ class KodiHelper(object):
         :obj:`str`
             Requested string or empty string
         """
-        src = xbmc if string_id < 30000 else self.get_addon()
+        src = xbmc if string_id < 30000 else self.addon
         locString = src.getLocalizedString(string_id)
         if isinstance(locString, unicode):
             locString = locString.encode('utf-8')
@@ -1651,7 +1422,7 @@ class KodiHelper(object):
         :param event: the string idetifier of the event
         :return: None
         """
-        addon = self.get_addon()
+        addon = self.addon
         # Check if tracking is enabled
         enable_tracking = (addon.getSetting('enable_tracking') == 'true')
         if enable_tracking:

--- a/resources/lib/MSLCrypto.py
+++ b/resources/lib/MSLCrypto.py
@@ -1,0 +1,133 @@
+# pylint: skip-file
+# -*- coding: utf-8 -*-
+# Author: trummerjo
+# Module: MSLHttpRequestHandler
+# Created on: 26.01.2017
+# License: MIT https://goo.gl/5bMj3H
+
+from Cryptodome.Random import get_random_bytes
+from Cryptodome.Hash import HMAC, SHA256
+from Cryptodome.Cipher import PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Util import Padding
+from Cryptodome.Cipher import AES
+import json
+import base64
+
+class MSLCrypto():
+
+  def __init__(self, kodi_helper):
+    self.kodi_helper = kodi_helper
+    self.encryption_key = None
+    self.sign_key = None
+
+  def __init_generate_rsa_keys(self):
+    self.kodi_helper.log(msg='Create new RSA Keys')
+    # Create new Key Pair and save
+    self.rsa_key = RSA.generate(2048)
+
+  @staticmethod
+  def __base64key_decode(payload):
+    l = len(payload) % 4
+    if l == 2:
+      payload += '=='
+    elif l == 3:
+      payload += '='
+    elif l != 0:
+      raise ValueError('Invalid base64 string')
+    return base64.urlsafe_b64decode(payload.encode('utf-8'))
+
+  def toDict(self):
+    self.kodi_helper.log(msg='Provide RSA Keys to dict')
+    # Get the DER Base64 of the keys
+    encrypted_key = self.rsa_key.exportKey()
+
+    data = {
+      "encryption_key": base64.standard_b64encode(self.encryption_key),
+      'sign_key': base64.standard_b64encode(self.sign_key),
+      'rsa_key': base64.standard_b64encode(encrypted_key)
+    }
+    return data
+
+  def fromDict(self, msl_data):
+    need_handshake = False
+    rsa_key = None
+
+    try:
+      self.kodi_helper.log(msg='Parsing RSA Keys from Dict')
+      self.encryption_key = base64.standard_b64decode(msl_data['encryption_key'])
+      self.sign_key = base64.standard_b64decode(msl_data['sign_key'])
+      rsa_key = base64.standard_b64decode(msl_data['rsa_key'])
+      self.rsa_key = RSA.importKey(rsa_key)
+    except:
+      need_handshake = True
+
+    if not rsa_key:
+      need_handshake = True
+      self.__init_generate_rsa_keys()
+
+    if not (self.encryption_key and self.sign_key):
+      need_handshake = True
+
+    return need_handshake
+
+  def get_key_request(self):
+    raw_key = self.rsa_key.publickey().exportKey(format='DER')
+    public_key = base64.standard_b64encode(raw_key)
+
+    key_request = [{
+    'scheme': 'ASYMMETRIC_WRAPPED',
+    'keydata': {
+      'publickey': public_key,
+      'mechanism': 'JWK_RSA',
+      'keypairid': 'superKeyPair'
+    }
+    }]
+    return key_request
+
+  def parse_key_response(self, headerdata):
+    # Init Decryption
+    enc_key = headerdata['keyresponsedata']['keydata']['encryptionkey']
+    hmac_key = headerdata['keyresponsedata']['keydata']['hmackey']
+    encrypted_encryption_key = base64.standard_b64decode(enc_key)
+    encrypted_sign_key = base64.standard_b64decode(hmac_key)
+    cipher_rsa = PKCS1_OAEP.new(self.rsa_key)
+
+    # Decrypt encryption key
+    cipher_raw = cipher_rsa.decrypt(encrypted_encryption_key)
+    encryption_key_data = json.JSONDecoder().decode(cipher_raw)
+    self.encryption_key = self.__base64key_decode(encryption_key_data['k'])
+
+    # Decrypt sign key
+    sign_key_raw = cipher_rsa.decrypt(encrypted_sign_key)
+    sign_key_data = json.JSONDecoder().decode(sign_key_raw)
+    self.sign_key = self.__base64key_decode(sign_key_data['k'])
+
+  def decrypt(self, iv, data):
+    cipher = AES.new(self.encryption_key, AES.MODE_CBC, iv)
+    return Padding.unpad(cipher.decrypt(data), 16)
+
+  def encrypt(self, data, esn, sequence_number):
+    """
+    Encrypt the given Plaintext with the encryption key
+    :param plaintext:
+    :return: Serialized JSON String of the encryption Envelope
+    """
+    iv = get_random_bytes(16)
+    encryption_envelope = {
+        'ciphertext': '',
+        'keyid': esn + '_' + str(sequence_number),
+        'sha256': 'AA==',
+        'iv': base64.standard_b64encode(iv)
+    }
+    # Padd the plaintext
+    plaintext = Padding.pad(data, 16)
+    # Encrypt the text
+    cipher = AES.new(self.encryption_key, AES.MODE_CBC, iv)
+    citext = cipher.encrypt(plaintext)
+    encryption_envelope['ciphertext'] = base64.standard_b64encode(citext)
+
+    return encryption_envelope;
+
+  def sign(self, message):
+    return HMAC.new(self.sign_key, message, SHA256).digest()

--- a/resources/lib/MSLHttpRequestHandler.py
+++ b/resources/lib/MSLHttpRequestHandler.py
@@ -9,12 +9,9 @@
 import base64
 import BaseHTTPServer
 from urlparse import urlparse, parse_qs
-from resources.lib.MSL import MSL as Msl
-from resources.lib.KodiHelper import KodiHelper
 
-KODI_HELPER = KodiHelper()
-MSL = Msl(kodi_helper=KODI_HELPER)
-
+from SocketServer import TCPServer
+from resources.lib.MSL import MSL
 
 class MSLHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     """Handles & translates requests from Inputstream to Netflix"""
@@ -34,17 +31,17 @@ class MSLHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         if len(data) is 2:
             challenge = data[0]
             sid = base64.standard_b64decode(data[1])
-            b64license = MSL.get_license(challenge, sid)
+            b64license = self.server.MSL.get_license(challenge, sid)
             if b64license is not '':
                 self.send_response(200)
                 self.end_headers()
                 self.wfile.write(base64.standard_b64decode(b64license))
                 self.finish()
             else:
-                KODI_HELPER.log(msg='Error getting License')
+                self.nx_common.log(msg='Error getting License')
                 self.send_response(400)
         else:
-            KODI_HELPER.log(msg='Error in License Request')
+            self.nx_common.log(msg='Error in License Request')
             self.send_response(400)
 
     # pylint: disable=invalid-name
@@ -52,11 +49,18 @@ class MSLHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """Loads the XML manifest for the requested resource"""
         url = urlparse(self.path)
         params = parse_qs(url.query)
-        if 'id' not in params:
+        if 'action' in params:
+            if params['action'][0] is 'reset':
+                self.server.MSL.__perform_key_handshake()
+                self.send_response(200)
+        elif 'id' not in params:
             self.send_response(400, 'No id')
         else:
             # Get the manifest with the given id
-            data = MSL.load_manifest(int(params['id'][0]))
+            dolby = True if 'dolby' in params and params['dolby'][0].lower() == 'true' else 'false' 
+            hevc = True if 'hevc' in params and params['hevc'][0].lower() == 'true' else 'false' 
+
+            data = self.server.MSL.load_manifest(int(params['id'][0]), dolby, hevc)
             self.send_response(200)
             self.send_header('Content-type', 'application/xml')
             self.end_headers()
@@ -65,3 +69,13 @@ class MSLHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def log_message(self, *args):
         """Disable the BaseHTTPServer Log"""
         pass
+
+##################################
+
+class MSLTCPServer(TCPServer):
+
+    def __init__(self, server_address, nx_common):
+        nx_common.log(msg='Constructing MSLTCPServer')
+        self.nx_common = nx_common
+        self.MSL = MSL(nx_common)
+        TCPServer.__init__(self, server_address, MSLHttpRequestHandler)

--- a/resources/lib/MSLMediaDrm.py
+++ b/resources/lib/MSLMediaDrm.py
@@ -1,0 +1,152 @@
+from os import urandom
+import json
+import base64
+import xbmcdrm
+import pprint
+
+class MSLMediaDrmCrypto:
+
+  def __init__(self, kodi_helper):
+    self.kodi_helper = kodi_helper
+
+    self.keySetId = None
+    self.keyId = None
+    self.hmacKeyId = None
+
+    try:
+      self.cryptoSession = xbmcdrm.CryptoSession('edef8ba9-79d6-4ace-a3c8-27dcd51d21ed', 'AES/CBC/NoPadding', 'HmacSHA256')
+      self.kodi_helper.log(msg='Widevine CryptoSession successful constructed')
+    except:
+      self.cryptoSession = None
+      return
+
+    self.systemId = self.cryptoSession.GetPropertyString('systemId')
+    self.kodi_helper.log(msg='Widevine CryptoSession systemId:' + self.systemId)
+
+    algorithms = self.cryptoSession.GetPropertyString('algorithms')
+    self.kodi_helper.log(msg='Widevine CryptoSession algorithms:' + algorithms)
+
+  def __del__(self):
+    self.cryptoSession = None
+
+  def __getKeyRequest(self, data):
+     #No key update supported -> remove existing keys
+     self.cryptoSession.RemoveKeys()
+     keyRequest = self.cryptoSession.GetKeyRequest(data, 'application/xml', True, dict())
+     if keyRequest:
+       self.kodi_helper.log(msg='Widevine CryptoSession getKeyRequest successful with size:' + str(len(keyRequest)))
+       return keyRequest
+     else:
+       self.kodi_helper.log(msg='Widevine CryptoSession getKeyRequest failed!')
+
+  def __provideKeyResponse(self, data):
+    if len(data) == 0:
+      return false
+
+    self.keySetId = self.cryptoSession.ProvideKeyResponse(data)
+
+    if self.keySetId:
+      self.kodi_helper.log(msg='Widevine CryptoSession provideKeyResponse successful, keySetId:' + self.keySetId)
+    else:
+      self.kodi_helper.log(msg='Widevine CryptoSession provideKeyResponse failed!')
+
+    return self.keySetId != None
+
+  def toDict(self):
+    self.kodi_helper.log(msg='Provide Widevine keys to dict')
+    data = {
+      "key_set_id": base64.standard_b64encode(self.keySetId),
+      'key_id': base64.standard_b64encode(self.keyId),
+      'hmac_key_id': base64.standard_b64encode(self.hmacKeyId)
+    }
+    return data
+
+  def fromDict(self, msl_data):
+    need_handshake = False
+
+    if not self.cryptoSession:
+       return False
+
+    try:
+      self.kodi_helper.log(msg='Parsing Widevine keys from Dict')
+      self.keySetId = base64.standard_b64decode(msl_data['key_set_id'])
+      self.keyId = base64.standard_b64decode(msl_data['key_id'])
+      self.hmacKeyId = base64.standard_b64decode(msl_data['hmac_key_id'])
+
+      self.cryptoSession.RestoreKeys(self.keySetId)
+
+    except:
+      need_handshake = True
+
+    return need_handshake
+
+  def get_key_request(self):
+    drmKeyRequest = self.__getKeyRequest(bytes([10, 122, 0, 108, 56, 43]))
+
+    key_request = [{
+    'scheme': 'WIDEVINE',
+    'keydata': {
+      'keyrequest': base64.standard_b64encode(drmKeyRequest)
+    }
+    }]
+
+    return key_request
+
+  def parse_key_response(self, headerdata):
+    # Init Decryption
+    key_resonse = base64.standard_b64decode(headerdata['keyresponsedata']['keydata']['cdmkeyresponse'])
+
+    if not self.__provideKeyResponse(key_resonse):
+      return
+
+    self.keyId = base64.standard_b64decode(headerdata['keyresponsedata']['keydata']['encryptionkeyid'])
+    self.hmacKeyId = base64.standard_b64decode(headerdata['keyresponsedata']['keydata']['hmackeyid'])
+
+  def decrypt(self, iv, data):
+    decrypted = self.cryptoSession.Decrypt(self.keyId, data, iv)
+
+    if decrypted:
+      self.kodi_helper.log(msg='Widevine CryptoSession decrypt successful: ' + str(len(decrypted)) + ' bytes returned')
+
+      # remove PKCS5Padding
+      pad = decrypted[len(decrypted) - 1]
+
+      return decrypted[:-pad].decode('utf-8')
+    else:
+     self.kodi_helper.log(msg='Widevine CryptoSession decrypt failed!')
+
+  def encrypt(self, data, esn, sequence_number):
+
+    iv = urandom(16)
+
+    # Add PKCS5Padding
+    pad = 16 - len(data) % 16
+    newData = data + ''.join([chr(pad)] * pad)
+
+    encrypted = self.cryptoSession.Encrypt(self.keyId, newData, iv)
+
+    if encrypted:
+      self.kodi_helper.log(msg='Widevine CryptoSession encrypt successful: ' + str(len(encrypted)) + ' bytes returned')
+
+      encryption_envelope = {
+        'version' : 1,
+        'ciphertext': base64.standard_b64encode(encrypted),
+        'sha256': 'AA==',
+        'keyid': base64.standard_b64encode(self.keyId),
+        #'cipherspec' : 'AES/CBC/PKCS5Padding',
+        'iv': base64.standard_b64encode(iv)
+      }
+      return encryption_envelope
+    else:
+     self.kodi_helper.log(msg='Widevine CryptoSession encrypt failed!')
+
+  def sign(self, message):
+    signature = self.cryptoSession.Sign(self.hmacKeyId, message)
+    if signature:
+      self.kodi_helper.log(msg='Widevine CryptoSession sign success: length:' + str(len(signature)))
+      return signature
+    else:
+      self.kodi_helper.log(msg='Widevine CryptoSession sign failed!')
+
+  def verify(self, message, signature):
+    return self.cryptoSession.Verify(self.hmacKeyId, message, signature)

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -20,10 +20,9 @@ import urllib2
 from urlparse import parse_qsl, urlparse
 from datetime import datetime
 import xbmc
-import xbmcvfs
-from xbmcaddon import Addon
 import resources.lib.NetflixSession as Netflix
 from resources.lib.utils import noop, log
+from resources.lib.KodiHelper import KodiHelper
 
 
 class Navigation(object):
@@ -33,7 +32,7 @@ class Navigation(object):
     for the Kodi view & the Netflix model
     """
 
-    def __init__(self, kodi_helper, library, base_url, log_fn=noop):
+    def __init__(self, nx_common, library):
         """
         Takes the instances & configuration options needed to drive the plugin
 
@@ -51,10 +50,14 @@ class Navigation(object):
         log_fn : :obj:`fn`
              optional log function
         """
-        self.kodi_helper = kodi_helper
+        self.nx_common = nx_common
+        self.kodi_helper = KodiHelper(
+            plugin_handle=nx_common.plugin_handle,
+            base_url=nx_common.base_url,
+            library=library)
         self.library = library
-        self.base_url = base_url
-        self.log = log_fn
+        self.base_url = self.nx_common.base_url
+        self.log = self.nx_common.log
 
     @log
     def router(self, paramstring):
@@ -100,12 +103,12 @@ class Navigation(object):
 
         # check if one of the before routing options decided to killthe routing
         if 'exit' in options:
-            self.kodi_helper.log(msg='exit in options')
+            self.nx_common.log(msg='exit in options')
             return False
         if 'action' not in params.keys():
             # show the profiles
-            if self.kodi_helper.get_setting('autologin_enable') == 'true':
-                profile_id = self.kodi_helper.get_setting('autologin_id')
+            if self.nx_common.get_setting('autologin_enable') == 'true':
+                profile_id = self.nx_common.get_setting('autologin_id')
                 if profile_id != '':
                     self.call_netflix_service({
                         'method': 'switch_profile',
@@ -197,7 +200,7 @@ class Navigation(object):
         elif action == 'play_video':
             # play a video, check for adult pin if needed
             adult_pin = None
-            adult_setting = self.kodi_helper.get_setting('adultpin_enable')
+            adult_setting = self.nx_common.get_setting('adultpin_enable')
             ask_for_adult_pin = adult_setting.lower() == 'true'
             if ask_for_adult_pin is True:
                 if self.check_for_adult_pin(params=params):
@@ -257,16 +260,12 @@ class Navigation(object):
             infoLabels = ast.literal_eval(infoLabels)
         except:
             infoLabels = {}
-        esn = self._check_response(self.call_netflix_service({
-            'method': 'get_esn'}))
-        if esn:
-            play = self.kodi_helper.play_item(
-                esn=esn,
-                video_id=video_id,
-                start_offset=start_offset,
-                infoLabels=infoLabels)
-            return play
-        return False
+
+        play = self.kodi_helper.play_item(
+            video_id=video_id,
+            start_offset=start_offset,
+            infoLabels=infoLabels)
+        return play
 
     @log
     def show_search_results(self, term):
@@ -434,11 +433,11 @@ class Navigation(object):
                     'guid': user_data['guid'],
                     'cache': True}))
                 if items is False and i == 0:
-                    self.kodi_helper.log('show_video_list response is dirty')
+                    self.nx_common.log('show_video_list response is dirty')
                     return False
                 elif len(items) == 0:
                     if i == 0:
-                        self.kodi_helper.log('show_video_list items=0')
+                        self.nx_common.log('show_video_list items=0')
                         return False
                     break
                 req_count = Netflix.FETCH_VIDEO_REQUEST_COUNT
@@ -691,15 +690,13 @@ class Navigation(object):
             path=os.path.join(self.library.tvshow_path, showtitle))
         try:
             filepath = next(os.path.join(show_dir, fn)
-                            for fn in xbmcvfs.listdir(show_dir)[1]
+                            for fn in nx_common.list_dir(show_dir)[1]
                             if 'strm' in fn)
         except StopIteration:
             raise KeyError
 
         self.log('Reading contents of {}'.format(filepath.encode('utf-8')))
-        f = xbmcvfs.File(filepath)
-        buf = f.read()
-        f.close()
+        buf = nx_common.load_file(data_path='', filename=filepath)
         episode_id = re.search(r'video_id=(\d+)', buf).group(1)
         show_metadata = self._check_response(self.call_netflix_service({
             'method': 'fetch_metadata',
@@ -738,21 +735,18 @@ class Navigation(object):
         Deletes all current account data & prompts with dialogs for new ones
         """
         self._check_response(self.call_netflix_service({'method': 'logout'}))
-        self.kodi_helper.set_setting(key='email', value='')
-        self.kodi_helper.set_setting(key='password', value='')
+        self.nx_common.set_credentials('', '')
+
         raw_email = self.kodi_helper.dialogs.show_email_dialog()
         raw_password = self.kodi_helper.dialogs.show_password_dialog()
-        encoded_email = self.kodi_helper.encode(raw=raw_email)
-        encoded_password = self.kodi_helper.encode(raw=raw_password)
-        self.kodi_helper.set_setting(key='email', value=encoded_email)
-        self.kodi_helper.set_setting(key='password', value=encoded_password)
+        self.nx_common.set_credentials(raw_email, raw_password)
+
         account = {
             'email': raw_email,
             'password': raw_password,
         }
         if self.establish_session(account=account) is not True:
-            self.kodi_helper.set_setting(key='email', value='')
-            self.kodi_helper.set_setting(key='password', value='')
+            self.nx_common.set_credentials('', '')
             return self.kodi_helper.dialogs.show_login_failed_notify()
         return True
 
@@ -791,20 +785,21 @@ class Navigation(object):
             used later in the routing process
         """
         options = {}
-        credentials = self.kodi_helper.get_credentials()
-        # check if we have user settings, if not, set em
-        if credentials['email'] == '':
-            email = self.kodi_helper.dialogs.show_email_dialog()
-            self.kodi_helper.set_setting(key='email', value=email)
-            credentials['email'] = email
-        if credentials['password'] == '':
-            password = self.kodi_helper.dialogs.show_password_dialog()
-            self.kodi_helper.set_setting(key='password', value=password)
-            credentials['password'] = password
         # check login & try to relogin if necessary
         logged_in = self._check_response(self.call_netflix_service({
             'method': 'is_logged_in'}))
         if logged_in is False:
+            credentials = self.nx_common.get_credentials()
+            # check if we have user settings, if not, set em
+            if credentials['email'] == '':
+                email = self.kodi_helper.dialogs.show_email_dialog()
+                self.nx_common.set_setting(key='email', value=email)
+                credentials['email'] = email
+            if credentials['password'] == '':
+                password = self.kodi_helper.dialogs.show_password_dialog()
+                self.nx_common.set_setting(key='password', value=password)
+                credentials['password'] = password
+
             if self.establish_session(account=credentials) is not True:
                 self.kodi_helper.dialogs.show_login_failed_notify()
         # persist & load main menu selection
@@ -908,7 +903,7 @@ class Navigation(object):
             # check if we do not have a valid session,
             # in case that happens: (re)login
             if self._is_expired_session(response=response):
-                account = self.kodi_helper.get_credentials()
+                account = self.nx_common.get_credentials()
                 self.establish_session(account=account)
             message = response['message'] if 'message' in response else ''
             code = response['code'] if 'code' in response else ''
@@ -939,10 +934,7 @@ class Navigation(object):
         str
             Url + Port
         """
-        addon = self.kodi_helper.get_addon()
-        service_url = 'http://127.0.0.1:'
-        service_url += str(addon.getSetting('netflix_service_port'))
-        return service_url
+        return 'http://127.0.0.1:' + self.nx_common.get_setting('netflix_service_port')
 
     def call_netflix_service(self, params):
         """
@@ -992,4 +984,5 @@ class Navigation(object):
     def open_settings(self, url):
         """Opens a foreign settings dialog"""
         url = 'inputstream.adaptive' if url == 'is' else url
+        from xbmcaddon import Addon
         return Addon(url).openSettings()

--- a/resources/lib/NetflixCommon.py
+++ b/resources/lib/NetflixCommon.py
@@ -1,0 +1,142 @@
+import xbmc
+from xbmcaddon import Addon
+import xbmcvfs
+import json
+
+class NetflixCommon(object):
+    """
+    Stuff shared between / used from service and addon"""
+
+    def __init__(self, plugin_handle, base_url):
+
+        self.addon = Addon()
+        self.data_path = xbmc.translatePath(self.addon.getAddonInfo('profile'))
+        self.cookie_path = self.data_path + 'COOKIE'
+        self.plugin = self.addon.getAddonInfo('name')
+        self.verb_log = self.addon.getSetting('logging') == 'true'
+        self.plugin_handle = plugin_handle
+        self.base_url = base_url
+        self.version = self.addon.getAddonInfo('version')
+
+        xbmcvfs.mkdir(path=self.data_path)
+
+    def set_setting(self, name, value):
+        return self.addon.setSetting(name, value)
+
+    def get_setting(self, name):
+        return self.addon.getSetting(name)
+
+    def flush_settings(self):
+        self.addon = Addon()
+
+    def get_esn(self):
+        """
+        Returns the esn from settings
+        """
+        return self.addon.getSetting('esn')
+
+    def set_esn(self, esn):
+        """
+        Returns the esn from settings
+        """
+        stored_esn = self.get_esn()
+        if not stored_esn and esn:
+            self.set_setting('esn', esn)
+            self.delete_manifest_data()
+            return esn
+        return stored_esn
+
+    def get_credentials(self):
+        from NetflixCredentials import NetflixCredentials
+        email = self.get_setting('email')
+        password = self.get_setting('password')
+
+        if '@' in email:
+            self.set_credentials(email, password)
+            return {'email' : email, 'password' : password }
+
+        return NetflixCredentials().decode_credentials(email, password)
+
+    def set_credentials(self, email, password):
+        from NetflixCredentials import NetflixCredentials
+        encoded = NetflixCredentials().encode_credentials(email, password)
+        self.set_setting('email',encoded['email'])
+        self.set_setting('password',encoded['password'])
+
+    def log(self, msg, level=xbmc.LOGDEBUG):
+        """Adds a log entry to the Kodi log
+
+        Parameters
+        ----------
+        msg : :obj:`str`
+            Entry that should be turned into a list item
+
+        level : :obj:`int`
+            Kodi log level
+        """
+        if isinstance(msg, unicode):
+            msg = msg.encode('utf-8')
+        xbmc.log('[%s] %s' % (self.plugin, msg.__str__()), level)
+
+    @staticmethod
+    def check_folder_path(path):
+        """
+        Check if folderpath ends with path delimator
+        If not correct it (makes sure xbmcvfs.exists is working correct)
+        """
+        if isinstance(path, unicode):
+            check = path.encode('ascii', 'ignore')
+            if '/' in check and not str(check).endswith('/'):
+                end = u'/'
+                path = path + end
+                return path
+            if '\\' in check and not str(check).endswith('\\'):
+                end = u'\\'
+                path = path + end
+                return path
+        if '/' in path and not str(path).endswith('/'):
+            path = path + '/'
+            return path
+        if '\\' in path and not str(path).endswith('\\'):
+            path = path + '\\'
+            return path
+
+    @staticmethod
+    def file_exists(data_path, filename):
+        """
+        Checks if a given file exists
+        :param filename: The filename
+        :return: True if so
+        """
+        return xbmcvfs.exists(path=data_path + filename)
+
+    @staticmethod
+    def save_file(data_path, filename, content):
+        """
+        Saves the given content under given filename
+        :param filename: The filename
+        :param content: The content of the file
+        """
+
+        file_handle = xbmcvfs.File(
+            filepath=data_path + filename,
+            mode='w')
+        file_content = file_handle.write(content)
+        file_handle.close()
+
+    @staticmethod
+    def load_file(data_path, filename):
+        """
+        Loads the content of a given filename
+        :param filename: The file to load
+        :return: The content of the file
+        """
+        file_handle = xbmcvfs.File(
+            filepath=data_path + filename)
+        file_content = file_handle.read()
+        file_handle.close()
+        return file_content
+
+    @staticmethod
+    def list_dir(data_path):
+        return xbmcvfs.listdir(data_path)

--- a/resources/lib/NetflixCredentials.py
+++ b/resources/lib/NetflixCredentials.py
@@ -1,0 +1,84 @@
+import base64
+from Cryptodome import Random
+from Cryptodome.Cipher import AES
+from Cryptodome.Util import Padding
+from utils import uniq_id
+
+class NetflixCredentials(object):
+    """
+    Stuff shared between / used from service and addon"""
+
+    def __init__(self):
+        self.bs = 32
+        self.crypt_key = uniq_id()
+
+    def encode_credentials(self, email, password):
+        """Returns the users stored credentials
+
+        Returns
+        -------
+        :obj:`dict` of :obj:`str`
+            The users stored account data
+        """
+        # if everything is fine, we encode the values
+        if '' != email or '' != password:
+            return {
+                'email': self.encode(enc=email),
+                'password': self.encode(enc=password)
+            }
+
+        # if email is empty, we return an empty map
+        return {
+            'email': '',
+            'password': ''
+        }
+
+    def decode_credentials(self, email, password):
+        """Returns the users stored credentials
+
+        Returns
+        -------
+        :obj:`dict` of :obj:`str`
+            The users stored account data
+        """
+        # if everything is fine, we decode the values
+        if (email and '' != email) or (password and '' != password):
+            return {
+                'email': self.decode(enc=email),
+                'password': self.decode(enc=password)
+            }
+
+        # if email is empty, we return an empty map
+        return {
+            'email': '',
+            'password': ''
+        }
+
+    def encode(self, raw):
+        """
+        Encodes data
+
+        :param data: Data to be encoded
+        :type data: str
+        :returns:  string -- Encoded data
+        """
+        raw = Padding.pad(data_to_pad=raw, block_size=self.bs)
+        iv = Random.new().read(AES.block_size)
+        cipher = AES.new(self.crypt_key, AES.MODE_CBC, iv)
+        return base64.b64encode(iv + cipher.encrypt(raw))
+
+    def decode(self, enc):
+        """
+        Decodes data
+
+        :param data: Data to be decoded
+        :type data: str
+        :returns:  string -- Decoded data
+        """
+        enc = base64.b64decode(enc)
+        iv = enc[:AES.block_size]
+        cipher = AES.new(self.crypt_key, AES.MODE_CBC, iv)
+        decoded = Padding.unpad(
+            padded_data=cipher.decrypt(enc[AES.block_size:]),
+            block_size=self.bs).decode('utf-8')
+        return decoded

--- a/resources/lib/NetflixHttpRequestHandler.py
+++ b/resources/lib/NetflixHttpRequestHandler.py
@@ -8,27 +8,15 @@
 
 import json
 import BaseHTTPServer
+from SocketServer import TCPServer
 from urlparse import urlparse, parse_qs
-from resources.lib.KodiHelper import KodiHelper
 from resources.lib.utils import get_class_methods
 from resources.lib.NetflixSession import NetflixSession
 from resources.lib.NetflixHttpSubRessourceHandler import \
     NetflixHttpSubRessourceHandler
 
-KODI_HELPER = KodiHelper()
-NETFLIX_SESSION = NetflixSession(
-    cookie_path=KODI_HELPER.cookie_path,
-    data_path=KODI_HELPER.data_path,
-    verify_ssl=KODI_HELPER.get_ssl_verification_setting(),
-    log_fn=KODI_HELPER.log
-)
-
 # get list of methods & instance form the sub ressource handler
 METHODS = get_class_methods(class_item=NetflixHttpSubRessourceHandler)
-RES_HANDLER = NetflixHttpSubRessourceHandler(
-    kodi_helper=KODI_HELPER,
-    netflix_session=NETFLIX_SESSION)
-
 
 class NetflixHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     """Oppionionated internal proxy that dispatches requests to Netflix"""
@@ -57,7 +45,7 @@ class NetflixHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
             return self.send_error(404, error_msg)
 
         # call method & get the result
-        result = getattr(RES_HANDLER, method)(params)
+        result = getattr(self.server.res_handler, method)(params)
         self.send_response(200)
         self.send_header('Content-type', 'application/json')
         self.end_headers()
@@ -68,3 +56,19 @@ class NetflixHttpRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def log_message(self, *args):
         """Disable the BaseHTTPServer Log"""
         pass
+
+##################################
+
+class NetflixTCPServer(TCPServer):
+
+    def __init__(self, server_address, nx_common):
+        nx_common.log(msg='Constructing netflixTCPServer')
+
+        netflix_session = NetflixSession(
+            cookie_path=nx_common.cookie_path,
+            data_path=nx_common.data_path,
+            verify_ssl=(nx_common.get_setting('ssl_verification') == 'true'),
+            nx_common=nx_common)
+        self.res_handler = NetflixHttpSubRessourceHandler(nx_common=nx_common, netflix_session=netflix_session)
+
+        TCPServer.__init__(self, server_address, NetflixHttpRequestHandler)

--- a/resources/lib/NetflixHttpSubRessourceHandler.py
+++ b/resources/lib/NetflixHttpSubRessourceHandler.py
@@ -10,7 +10,7 @@ class NetflixHttpSubRessourceHandler(object):
     translates/executes them to requests for Netflix
     """
 
-    def __init__(self, kodi_helper, netflix_session):
+    def __init__(self, nx_common, netflix_session):
         """Sets up credentials & video_list_cache cache
         Assigns the netflix_session/kodi_helper instacnes
         Does the initial login if we have user data
@@ -23,9 +23,9 @@ class NetflixHttpSubRessourceHandler(object):
         netflix_session : :obj:`NetflixSession`
             instance of the NetflixSession class
         """
-        self.kodi_helper = kodi_helper
+        self.nx_common = nx_common
         self.netflix_session = netflix_session
-        self.credentials = self.kodi_helper.get_credentials()
+        self.credentials = self.nx_common.get_credentials()
         self.profiles = []
         self.video_list_cache = {}
         self.prefetch_login()
@@ -47,7 +47,7 @@ class NetflixHttpSubRessourceHandler(object):
             else:
                 if self.netflix_session.login(account=self.credentials):
                     self.profiles = self.netflix_session.profiles
-        self.kodi_helper.set_esn(self.netflix_session.esn)
+        self.nx_common.set_esn(self.netflix_session.esn)
 
     def is_logged_in(self, params):
         """Existing login proxy function
@@ -83,8 +83,7 @@ class NetflixHttpSubRessourceHandler(object):
         """
         self.profiles = []
         self.credentials = {'email': '', 'password': ''}
-        # delete esn data
-        self.kodi_helper.delete_manifest_data()
+
         return self.netflix_session.logout()
 
     def login(self, params):
@@ -155,7 +154,7 @@ class NetflixHttpSubRessourceHandler(object):
         guid = self.netflix_session.user_data.get('guid')
         cached_list = self.video_list_cache.get(guid, None)
         if cached_list is not None:
-            self.kodi_helper.log(msg='Serving cached list for user: ' + guid)
+            self.nx_common.log(msg='Serving cached list for user: ' + guid)
             return cached_list
         video_list_ids_raw = self.netflix_session.fetch_video_list_ids()
 

--- a/service.py
+++ b/service.py
@@ -9,14 +9,13 @@
 
 import threading
 import socket
-from SocketServer import TCPServer
-from datetime import datetime, timedelta
-import xbmc
-from resources.lib.KodiHelper import KodiHelper
-from resources.lib.KodiMonitor import KodiMonitor
-from resources.lib.MSLHttpRequestHandler import MSLHttpRequestHandler
-from resources.lib.NetflixHttpRequestHandler import NetflixHttpRequestHandler
 
+import xbmc
+from datetime import datetime, timedelta
+from resources.lib.NetflixCommon import NetflixCommon
+from resources.lib.KodiMonitor import KodiMonitor
+from resources.lib.MSLHttpRequestHandler import MSLTCPServer
+from resources.lib.NetflixHttpRequestHandler import NetflixTCPServer
 
 def select_unused_port():
     """
@@ -30,6 +29,9 @@ def select_unused_port():
     sock.close()
     return port
 
+# Setup plugin
+BASE_URL = sys.argv[0]
+PLUGIN_HANDLE = None
 
 def strp(value, form):
     """
@@ -57,36 +59,37 @@ class NetflixService(object):
     """
     def __init__(self):
         # init kodi helper (for logging)
-        self.kodi_helper = KodiHelper()
+        self.nx_common = NetflixCommon(plugin_handle=PLUGIN_HANDLE, base_url=BASE_URL)
 
         self.last_schedule_check = datetime.now()
-        self.schedule_check_interval = int(self.kodi_helper.get_setting(
+        self.schedule_check_interval = int(self.nx_common.get_setting(
             'schedule_check_interval'))
         self.startidle = 0
-        self.freq = int('0' + self.kodi_helper.get_setting('auto_update'))
+        self.freq = int('0' + self.nx_common.get_setting('auto_update'))
 
         # pick & store a port for the MSL service
         msl_port = select_unused_port()
-        self.kodi_helper.set_setting('msl_service_port', str(msl_port))
-        self.kodi_helper.log(msg='[MSL] Picked Port: ' + str(msl_port))
+        self.nx_common.set_setting('msl_service_port', str(msl_port))
+        self.nx_common.log(msg='[MSL] Picked Port: ' + str(msl_port))
 
         # pick & store a port for the internal Netflix HTTP proxy service
         ns_port = select_unused_port()
-        self.kodi_helper.set_setting('netflix_service_port', str(ns_port))
-        self.kodi_helper.log(msg='[NS] Picked Port: ' + str(ns_port))
+        self.nx_common.set_setting('netflix_service_port', str(ns_port))
+        self.nx_common.log(msg='[NS] Picked Port: ' + str(ns_port))
+
+        self.nx_common.flush_settings()
 
         # server defaults
-        TCPServer.allow_reuse_address = True
+        MSLTCPServer.allow_reuse_address = True
+        NetflixTCPServer.allow_reuse_address = True
 
         # configure the MSL Server
-        self.msl_server = TCPServer(('127.0.0.1', msl_port),
-                                    MSLHttpRequestHandler)
+        self.msl_server = MSLTCPServer(('127.0.0.1', msl_port), self.nx_common)
         self.msl_server.server_activate()
         self.msl_server.timeout = 1
 
         # configure the Netflix Data Server
-        self.ns_server = TCPServer(('127.0.0.1', ns_port),
-                                   NetflixHttpRequestHandler)
+        self.ns_server = NetflixTCPServer(('127.0.0.1', ns_port), self.nx_common)
         self.ns_server.server_activate()
         self.ns_server.timeout = 1
 
@@ -106,16 +109,18 @@ class NetflixService(object):
         self.msl_server.server_close()
         self.msl_server.socket.close()
         self.msl_server.shutdown()
-        self.kodi_helper.log(msg='Stopped MSL Service')
+        self.msl_server = None
+        self.nx_common.log(msg='Stopped MSL Service')
 
         # Netflix service shutdown sequence
         self.ns_server.server_close()
         self.ns_server.socket.close()
         self.ns_server.shutdown()
-        self.kodi_helper.log(msg='Stopped HTTP Service')
+        self.ns_server = None
+        self.nx_common.log(msg='Stopped HTTP Service')
 
     def _is_idle(self):
-        if self.kodi_helper.get_setting('wait_idle') != 'true':
+        if self.nx_common.get_setting('wait_idle') != 'true':
             return True
 
         lastidle = xbmc.getGlobalIdleTime()
@@ -127,16 +132,16 @@ class NetflixService(object):
         return idletime >= 300
 
     def _update_running(self):
-        update = self.kodi_helper.get_setting('update_running') or 'false'
+        update = self.nx_common.get_setting('update_running') or 'false'
         if update != 'false':
             starttime = strp(update, '%Y-%m-%d %H:%M')
             if (starttime + timedelta(hours=6)) <= datetime.now():
-                self.kodi_helper.set_setting('update_running', 'false')
-                self.kodi_helper.log(
+                self.nx_common.set_setting('update_running', 'false')
+                self.nx_common.log(
                     'Canceling previous library update - duration > 6 hours',
                     xbmc.LOGWARNING)
             else:
-                self.kodi_helper.log('DB Update already running')
+                self.nx_common.log('DB Update already running')
                 return True
         return False
 
@@ -145,14 +150,14 @@ class NetflixService(object):
         Main loop. Runs until xbmc.Monitor requests abort
         """
         self._start_servers()
-        monitor = KodiMonitor(self.kodi_helper, self.kodi_helper.log)
+        monitor = KodiMonitor(self.nx_common, self.nx_common.log)
         while not monitor.abortRequested():
             monitor.update_playback_progress()
             try:
                 if self.library_update_scheduled() and self._is_idle():
                     self.update_library()
             except RuntimeError as exc:
-                self.kodi_helper.log(
+                self.nx_common.log(
                     'RuntimeError: {}'.format(exc), xbmc.LOGERROR)
             if monitor.waitForAbort(5):
                 break
@@ -168,14 +173,14 @@ class NetflixService(object):
                                    minutes=self.schedule_check_interval))
 
         if not self.freq or now <= next_schedule_check:
-            self.kodi_helper.log('Auto-update disabled or schedule check '
+            self.nx_common.log('Auto-update disabled or schedule check '
                                  'interval not complete yet ({} / {}).'
                                  .format(now, next_schedule_check))
             return False
 
         self.last_schedule_check = now
-        time = self.kodi_helper.get_setting('update_time') or '00:00'
-        lastrun_date = (self.kodi_helper.get_setting('last_update') or
+        time = self.nx_common.get_setting('update_time') or '00:00'
+        lastrun_date = (self.nx_common.get_setting('last_update') or
                         '1970-01-01')
 
         lastrun_full = lastrun_date + ' ' + time[0:5]
@@ -183,7 +188,7 @@ class NetflixService(object):
         freqdays = [0, 1, 2, 5, 7][self.freq]
         nextrun = lastrun + timedelta(days=freqdays)
 
-        self.kodi_helper.log(
+        self.nx_common.log(
             'It\'s currently {}, next run is scheduled for {}'
             .format(now, nextrun))
 
@@ -194,11 +199,11 @@ class NetflixService(object):
         Triggers an update of the local Kodi library
         """
         if not self._update_running():
-            self.kodi_helper.log('Triggering library update', xbmc.LOGNOTICE)
+            self.nx_common.log('Triggering library update', xbmc.LOGNOTICE)
             xbmc.executebuiltin(
                 ('XBMC.RunPlugin(plugin://{}/?action=export-new-episodes'
                  '&inbackground=True)')
-                .format(self.kodi_helper.get_addon().getAddonInfo('id')))
+                .format(self.nx_common.get_addon().getAddonInfo('id')))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
MSL Widevine Cryptosession (used / required on android devices) required a split of the single MSL class into multiple parts.
The refactoring was made to be able to add more crypto session modes in the future (e.g. playready for windows devices)

During the refactoring I cleaned up existing base / helper classes in "used by addon / used by session / msl" to reduce number of imported modules. 

## Note
Widevine Cryptosession / Android is only working with newest kodi master (Leia), because the DRM Cryptosession is implemented in kodi itself.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?
