### PR TITLE
Sync My List and library exports

### DIFF
--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -303,3 +303,7 @@ msgstr "Prüfe alle X Minuten ob Startzeitpunkt erreicht"
 msgctxt "#30074"
 msgid "View for exported"
 msgstr "Ansicht für Exportiert"
+
+msgctxt "#30075"
+msgid "Add exported items to my list"
+msgstr "Exportierte Einträge zu Meine Liste hinzufügen"

--- a/resources/language/resource.language.de_de/strings.po
+++ b/resources/language/resource.language.de_de/strings.po
@@ -307,3 +307,7 @@ msgstr "Ansicht für Exportiert"
 msgctxt "#30075"
 msgid "Add exported items to my list"
 msgstr "Exportierte Einträge zu Meine Liste hinzufügen"
+
+msgctxt "#30076"
+msgid "Export items from My List"
+msgstr "Einträge von Meine Liste exportieren"

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -315,3 +315,7 @@ msgstr ""
 msgctxt "#30074"
 msgid "View for exported"
 msgstr ""
+
+msgctxt "#30075"
+msgid "Add exported items to my list"
+msgstr ""

--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -319,3 +319,7 @@ msgstr ""
 msgctxt "#30075"
 msgid "Add exported items to my list"
 msgstr ""
+
+msgctxt "#30076"
+msgid "Export items from My List"
+msgstr ""

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -741,6 +741,15 @@ class KodiHelper(object):
             url=build_url({'action': 'export-new-episodes','inbackground': True}),
             listitem=li,
             isFolder=False)
+        li = xbmcgui.ListItem(
+            label=self.get_local_string(30076),
+            iconImage=self.default_fanart)
+        li.setProperty('fanart_image', self.default_fanart)
+        xbmcplugin.addDirectoryItem(
+            handle=self.plugin_handle,
+            url=build_url({'action': 'export-my-list'}),
+            listitem=li,
+            isFolder=False)
         listing = content
         for video in listing[0]:
             year = self.library.get_exported_movie_year(title=video)

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -612,6 +612,8 @@ class Navigation(object):
                     episodes=episodes,
                     build_url=self.build_url,
                     in_background=in_background)
+            if self.kodi_helper.get_setting('add_exported_to_list') == 'true':
+                self.add_to_list(video_id)
             return True
         self.kodi_helper.dialogs.show_no_metadata_notify()
         return False

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -13,6 +13,7 @@
     <setting id="enablelibraryfolder" type="bool" label="30026" default="false"/>
     <setting id="customlibraryfolder" type="folder" label="30027" enable="eq(-1,true)" default="special://profile/addon_data/plugin.video.netflix" source="auto" option="writeable" subsetting="true"/>
     <setting id="customexportname" type="bool" label="30036" default="false"/>
+    <setting id="add_exported_to_list" type="bool" label="30075" default="false"/>
     <setting label="30065" type="lsep"/>
     <setting id="auto_update" type="enum" label="30064" lvalues="30066|30067|30068|30069|30070" default="0"/>
     <setting id="update_time" type="time" label="30071" visible="gt(-1,0)" default="00:00" subsetting="true"/>


### PR DESCRIPTION
This implements #318.

You can choose to automatically add exported movies and shows to "My List" (via a setting) and export all items of "My List" to your local library.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?