### PR TITLE
fix: Improve ESN generation on Android (invalid ESN generated on some devices.)

### DIFF
--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -2010,21 +2010,24 @@ class NetflixSession(object):
         """
         # we generate an esn from device strings for android
         import subprocess
+        import re
         try:
             manufacturer = subprocess.check_output(
                 ['/system/bin/getprop', 'ro.product.manufacturer'])
             if manufacturer:
                 esn = 'NFANDROID1-PRV-'
                 input = subprocess.check_output(
-                    ['/system/bin/getprop', 'ro.nrdp.modelgroup'])
+                    ['/system/bin/getprop', 'ro.nrdp.modelgroup']
+                    ).strip(' \t\n\r')
                 if not input:
                     esn += 'T-L3-'
                 else:
-                    esn += input.strip(' \t\n\r') + '-'
-                esn += '{:5}'.format(manufacturer.strip(' \t\n\r').upper())
+                    esn += input + '-'
+                esn += '{:=<5}'.format(manufacturer.strip(' \t\n\r').upper())
                 input = subprocess.check_output(
                     ['/system/bin/getprop', 'ro.product.model'])
                 esn += input.strip(' \t\n\r').replace(' ', '=').upper()
+                esn = re.sub(r'[^A-Za-z0-9=-]', '=', esn)
                 self.nx_common.log(msg='Android generated ESN:' + esn)
                 return esn
         except OSError as e:


### PR DESCRIPTION
- Trim ro.nrdp.modelgroup *before* checking if it's empty (since getprop returns '\n' if the property is not set)
- Change the padding character in format specifier for manufacturer (default is ' ' which is invalid)
- Replace all illegal characters by '='.

This is still not perfect though, as I have a device that has ro.nrdp.modelgroup set but is actually L3 (and fails unless I manually add -T-L3 in the ESN) and I have a different device that is L1 but doesn't have ro.nrdp.modelgroup so it's stuck in SD until I manually remove -T-L3 from its ESN.

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?