### PR TITLE
Fix exceptions when parsing falkorCache.

### DIFF
--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -10,6 +10,7 @@
 import os
 import sys
 import json
+import re
 from time import time
 from urllib import quote, unquote
 from re import compile as recompile
@@ -176,7 +177,8 @@ class NetflixSession(object):
         falkorCache = recompile(r"\{([^)]+)\}").findall(falkorCache)
         if not falkorCache:
             return profiles
-        falkorDict = json.loads('{' + falkorCache[0] + '}')
+        falkorCache = re.sub(r'"focalPoint":"{"([^}]*)}"', r'"focalPoint":{"\1}', falkorCache[0])
+        falkorDict = json.loads('{' + falkorCache + '}')
         _profiles = falkorDict['profiles']
 
         for guid in _profiles:


### PR DESCRIPTION
Fix exceptions when parsing falkorCache.
    
For some reason we get something like:
      {"focalPoint":"{"x":0.4104,"y":0.4472}"
    
Which is obviously invalid. The substitution should change it to:
      {"focalPoint":{"x":0.4104,"y":0.4472}

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you successfully ran tests with your changes locally?