### PR TITLE
add option to skip credits

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -315,3 +315,15 @@ msgstr ""
 msgctxt "#30074"
 msgid "View for exported"
 msgstr ""
+
+msgctxt "#30075"
+msgid "Ask to skip credits"
+msgstr ""
+
+msgctxt "#30076"
+msgid "Skip back"
+msgstr ""
+
+msgctxt "#30077"
+msgid "Skip intro"
+msgstr ""

--- a/resources/language/resource.language.fr_fr/strings.po
+++ b/resources/language/resource.language.fr_fr/strings.po
@@ -315,3 +315,15 @@ msgstr "Vérifier toutes les X minutes si mise à jour programmée"
 msgctxt "#30074"
 msgid "View for exported"
 msgstr "Vue pour les exports"
+
+msgctxt "#30075"
+msgid "Ask to skip credits"
+msgstr "Proposer de passer les crédits"
+
+msgctxt "#30076"
+msgid "Skip back"
+msgstr "Ignorer le récap"
+
+msgctxt "#30077"
+msgid "Skip intro"
+msgstr "Ignorer l'introduction"

--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -45,6 +45,7 @@ TAGGED_WINDOW_ID = 10000
 PROP_NETFLIX_PLAY = 'netflix_playback'
 PROP_PLAYBACK_INIT = 'initialized'
 PROP_PLAYBACK_TRACKING = 'tracking'
+PROP_METADATA = 'netflix_metadata'
 
 def _update_if_present(source_dict, source_att, target_dict, target_att):
     if source_dict.get(source_att):
@@ -876,7 +877,7 @@ class KodiHelper(object):
         self.set_custom_view(VIEW_EPISODE)
         return True
 
-    def play_item(self, video_id, start_offset=-1, infoLabels={}):
+    def play_item(self, video_id, start_offset=-1, infoLabels={}, metadata={}):
         """Plays a video
 
         Parameters
@@ -967,6 +968,12 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             succeeded=True,
             listitem=play_item)
+
+        # set window property to store metadata (skip intro, etc...)
+        xbmcgui.Window(TAGGED_WINDOW_ID).setProperty(
+            PROP_METADATA,
+            json.dumps(metadata)
+        )
 
         # set window property to enable recognition of playbacks
         xbmcgui.Window(TAGGED_WINDOW_ID).setProperty(

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -268,10 +268,19 @@ class Navigation(object):
         except:
             infoLabels = {}
 
+        try:
+            metadata = self._check_response(self.call_netflix_service({
+                'method': 'fetch_metadata',
+                'video_id': video_id
+            }))
+        except:
+            metadata = {}
+
         play = self.kodi_helper.play_item(
             video_id=video_id,
             start_offset=start_offset,
-            infoLabels=infoLabels)
+            infoLabels=infoLabels,
+            metadata=metadata)
         return play
 
     @log

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -30,10 +30,11 @@
     <setting id="viewmodeseason" type="number" label="30042" enable="eq(-5,true)" default="504"/>
     <setting id="viewmodeepisode" type="number" label="30043" enable="eq(-6,true)" default="55"/>
     <setting id="viewmodeexported" type="number" label="30074" enable="eq(-7,true)" default="504"/>
+    <setting id="showskipcredits" type="bool" label="30075" default="true"/>
   </category>
   <category label="30023">
     <setting id="enable_dolby_sound" type="bool" label="30033" default="true"/>
-    <setting id="enable_hevc_profiles" type="bool" label="30060" default="false"/>    
+    <setting id="enable_hevc_profiles" type="bool" label="30060" default="false"/>
     <setting id="ssl_verification" type="bool" label="30024" default="true"/>
     <setting id="enable_tracking" type="bool" label="30032" default="true"/>
     <setting id="esn" type="text" label="30034" value="" default=""/>

--- a/service.py
+++ b/service.py
@@ -169,15 +169,22 @@ class NetflixService(object):
         """
         self._start_servers()
         monitor = KodiMonitor(self.nx_common, self.nx_common.log)
+        counter = 0
         while not monitor.abortRequested():
-            monitor.update_playback_progress()
-            try:
-                if self.library_update_scheduled() and self._is_idle():
-                    self.update_library()
-            except RuntimeError as exc:
-                self.nx_common.log(
-                    'RuntimeError: {}'.format(exc), xbmc.LOGERROR)
-            if monitor.waitForAbort(5):
+            counter += 1  # increment the counter
+            # every 1 seconds
+            if self.nx_common.get_addon().getSetting('showskipcredits') == 'true':
+                monitor.check_skip_intro()
+            if counter % 5 == 0:  # every 5 seconds only
+                counter = 0  # reset counter
+                monitor.update_playback_progress()
+                try:
+                    if self.library_update_scheduled() and self._is_idle():
+                        self.update_library()
+                except RuntimeError as exc:
+                    self.nx_common.log(
+                        'RuntimeError: {}'.format(exc), xbmc.LOGERROR)
+            if monitor.waitForAbort(1):
                 break
         self._shutdown()
 


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

#382 skip intro.
Add an option in addon setting to ask "skip intro / recap" when launching a movie / video. If set to true : show a dialog to user at the time provided by Netflix metadata, to skip introduction.