### PR TITLE
Use correct poster, landscape and fanart artworks. Add clearlogo.

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -995,16 +995,19 @@ class KodiHelper(object):
             'landscape': '',
             'thumb': '',
             'fanart': '',
-            'poster': ''
+            'poster': '',
+            'clearlogo': ''
         })
         if 'boxarts' in dict(entry).keys() and not isinstance(entry.get('boxarts'), dict):
             big = entry.get('boxarts', '')
             small = big
+            poster = big
         if 'boxarts' in dict(entry).keys() and isinstance(entry.get('boxarts'), dict):
             big = entry.get('boxarts', {}).get('big')
             small = entry.get('boxarts', {}).get('small')
+            poster = entry.get('boxarts', {}).get('poster')
             art.update({
-                'poster': big or small,
+                'poster': poster,
                 'landscape': big or small,
                 'thumb': big or small,
                 'fanart': big or small
@@ -1016,10 +1019,18 @@ class KodiHelper(object):
                     url=str(big))
 
         if 'interesting_moment' in dict(entry).keys():
+            if entry.get('type') == 'episode':
+                art.update({'thumb': entry['interesting_moment'],
+                            'landscape': entry['interesting_moment']})
             art.update({
-                'poster': entry['interesting_moment'],
                 'fanart': entry['interesting_moment']
             })
+        if 'artwork' in dict(entry).keys():
+            art.update({
+                'fanart': entry['artwork']
+            })
+        if 'clearlogo' in dict(entry).keys():
+            art.update({'clearlogo': entry['clearlogo']})
         if 'thumb' in dict(entry).keys():
             art.update({'thumb': entry['thumb']})
         if 'fanart' in dict(entry).keys():

--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -24,6 +24,14 @@ except:
 
 FETCH_VIDEO_REQUEST_COUNT = 26
 
+ART_BILLBOARD_SIZE = '_1920x1080'
+ART_MOMENT_SIZE_SMALL = '_665x375'
+ART_MOMENT_SIZE_LARGE = '_1920x1080'
+ART_BOX_SIZE_POSTER = '_342x684'
+ART_BOX_SIZE_SMALL = '_665x375'
+ART_BOX_SIZE_LARGE = '_1920x1080'
+ART_LOGO_SIZE = '_400x90'
+
 
 class NetflixSession(object):
     """Helps with login/session management of Netflix users & API handling"""
@@ -823,13 +831,12 @@ class NetflixSession(object):
 
         # determine artwork
         boxarts = video.get('boxarts', {})
-        bx_small = boxarts.get('_342x192', {}).get('jpg', {}).get('url')
-        bx_big = boxarts.get('_1280x720', {}).get('jpg', {}).get('url')
-        raw_moment = video.get('interestingMoment', {})
-        moment = raw_moment.get('_665x375', {}).get('jpg', {}).get('url')
-        raw_by_type = video.get('artWorkByType', {})
-        billboard = raw_by_type.get('BILLBOARD', {})
-        artwork = billboard.get('_1280x720', {}).get('jpg', {}).get('url')
+        bx_small = boxarts.get(ART_BOX_SIZE_SMALL, {}).get('jpg', {}).get('url')
+        bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
+        bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
+        moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
+        artwork = video.get('artWorkByType', {}).get('BILLBOARD', {}).get(ART_BILLBOARD_SIZE, {}).get('jpg', {}).get('url')
+        logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
             id: {
@@ -864,10 +871,12 @@ class NetflixSession(object):
                 'maturity': maturity,
                 'boxarts': {
                     'small': bx_small,
-                    'big': bx_big
+                    'big': bx_big,
+                    'poster': bx_poster
                 },
                 'interesting_moment': moment,
                 'artwork': artwork,
+                'clearlogo': logo
             }
         }
 
@@ -1175,8 +1184,14 @@ class NetflixSession(object):
                 }
             }
         """
-        raw_moment = video.get('interestingMoment', {})
-        moment = raw_moment.get('_665x375', {}).get('jpg', {}).get('url')
+        # determine artwork
+        boxarts = video.get('boxarts', {})
+        bx_small = boxarts.get(ART_BOX_SIZE_SMALL, {}).get('jpg', {}).get('url')
+        bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
+        bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
+        moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
+        artwork = video.get('artWorkByType', {}).get('BILLBOARD', {}).get(ART_BILLBOARD_SIZE, {}).get('jpg', {}).get('url')
+        logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
         return {
             season['summary']['id']: {
                 'idx': sorting[season['summary']['id']],
@@ -1184,10 +1199,14 @@ class NetflixSession(object):
                 'text': season['summary']['name'],
                 'shortName': season['summary']['shortName'],
                 'boxarts': {
-                    'small': video['boxarts']['_342x192']['jpg']['url'],
-                    'big': video['boxarts']['_1280x720']['jpg']['url']
+                    'small': bx_small,
+                    'big': bx_big,
+                    'poster': bx_poster
                 },
                 'interesting_moment': moment,
+                'artwork': artwork,
+                'clearlogo': logo,
+                'type': 'season'
             }
         }
 
@@ -1311,8 +1330,14 @@ class NetflixSession(object):
         rating = episode.get('userRating', {}).get('predicted', 0)
         rating = episode.get('userRating', {}).get('average', rating)
 
-        raw_moment = episode.get('interestingMoment', {})
-        moment = raw_moment.get('_1280x720', {}).get('jpg', {}).get('url')
+        # determine artwork
+        boxarts = episode.get('boxarts', {})
+        bx_small = boxarts.get(ART_BOX_SIZE_SMALL, {}).get('jpg', {}).get('url')
+        bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
+        bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
+        moment = episode.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
+        artwork = episode.get('artWorkByType', {}).get('BILLBOARD', {}).get(ART_BILLBOARD_SIZE, {}).get('jpg', {}).get('url')
+        logo = episode.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
             episode['summary']['id']: {
@@ -1330,13 +1355,18 @@ class NetflixSession(object):
                 'maturity': episode['maturity'],
                 'playcount': (0, 1)[episode.get('watched')],
                 'rating': rating,
-                'thumb': episode['interestingMoment']['_665x375']['jpg']['url'],
-                'fanart': moment,
-                'poster': episode['boxarts']['_1280x720']['jpg']['url'],
-                'banner': episode['boxarts']['_342x192']['jpg']['url'],
                 'mediatype': episode.get('summary', {}).get('type', 'movie'),
                 'my_list': episode['queue']['inQueue'],
-                'bookmark': episode['bookmarkPosition']
+                'bookmark': episode['bookmarkPosition'],
+                'boxarts': {
+                    'small': bx_small,
+                    'big': bx_big,
+                    'poster': bx_poster
+                },
+                'interesting_moment': moment,
+                'artwork': artwork,
+                'clearlogo': logo,
+                'type': 'episode'
             }
         }
 
@@ -1398,12 +1428,14 @@ class NetflixSession(object):
 
         paths = [
             item_path + item_titles + item_pagination + ['reference', ['summary', 'releaseYear', 'title', 'synopsis', 'regularSynopsis', 'evidence', 'queue', 'episodeCount', 'info', 'maturity', 'runtime', 'seasonCount', 'releaseYear', 'userRating', 'numSeasonsLabel', 'bookmarkPosition', 'watched', 'delivery', 'seasonList', 'current']],
-            item_path + item_titles + item_pagination + ['reference', 'bb2OGLogo', '_400x90', 'png'],
-            item_path + item_titles + item_pagination + ['reference', 'boxarts', '_342x192', 'jpg'],
-            item_path + item_titles + item_pagination + ['reference', 'boxarts', '_1280x720', 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
+            item_path + item_titles + item_pagination + ['reference', 'boxarts', ART_BOX_SIZE_SMALL, 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'boxarts', ART_BOX_SIZE_LARGE, 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'boxarts', ART_BOX_SIZE_POSTER, 'jpg'],
             item_path + item_titles + item_pagination + ['reference', 'storyarts', '_1632x873', 'jpg'],
-            item_path + item_titles + item_pagination + ['reference', 'interestingMoment', '_665x375', 'jpg'],
-            item_path + item_titles + item_pagination + ['reference', 'artWorkByType', 'BILLBOARD', '_1280x720', 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg'],
             item_path + item_titles + item_pagination + ['reference', 'cast', {'from': 0, 'to': 15}, ['id', 'name']],
             item_path + item_titles + item_pagination + ['reference', 'cast', 'summary'],
             item_path + item_titles + item_pagination + ['reference', 'genres', {'from': 0, 'to': 5}, ['id', 'name']],
@@ -1449,12 +1481,14 @@ class NetflixSession(object):
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'tags', 'summary'],
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", ['creators', 'directors'], {'from': 0, 'to': 49}, ['id', 'name']],
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", ['creators', 'directors'], 'summary'],
-            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'bb2OGLogo', '_400x90', 'png'],
-            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'boxarts', '_342x192', 'jpg'],
-            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'boxarts', '_1280x720', 'jpg'],
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'boxarts', ART_BOX_SIZE_SMALL, 'jpg'],
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'boxarts', ART_BOX_SIZE_LARGE, 'jpg'],
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'boxarts', ART_BOX_SIZE_POSTER, 'jpg'],
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'storyarts', '_1632x873', 'jpg'],
-            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'interestingMoment', '_665x375', 'jpg'],
-            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'artWorkByType', 'BILLBOARD', '_1280x720', 'jpg']
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg']
         ]
 
         response = self._path_request(paths=paths)
@@ -1543,10 +1577,14 @@ class NetflixSession(object):
         paths = [
             ['videos', id, 'seasonList', {'from': list_from, 'to': list_to}, 'summary'],
             ['videos', id, 'seasonList', 'summary'],
-            ['videos', id, 'boxarts',  '_342x192', 'jpg'],
-            ['videos', id, 'boxarts', '_1280x720', 'jpg'],
+            ['videos', id, 'boxarts',  ART_BOX_SIZE_SMALL, 'jpg'],
+            ['videos', id, 'boxarts', ART_BOX_SIZE_LARGE, 'jpg'],
+            ['videos', id, 'boxarts', ART_BOX_SIZE_POSTER, 'jpg'],
             ['videos', id, 'storyarts',  '_1632x873', 'jpg'],
-            ['videos', id, 'interestingMoment', '_665x375', 'jpg']
+            ['videos', id, 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
+            ['videos', id, 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
+            ['videos', id, 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
+            ['videos', id, 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg']
         ]
         response = self._path_request(paths=paths)
         return self._process_response(response=response, component='Seasons')
@@ -1584,10 +1622,13 @@ class NetflixSession(object):
             # ['videos', season_id, ['creators', 'directors'], 'summary'],
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'genres', {'from': 0, 'to': 1}, ['id', 'name']],
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'genres', 'summary'],
-            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'interestingMoment', '_1280x720', 'jpg'],
-            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'interestingMoment', '_665x375', 'jpg'],
-            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', '_342x192', 'jpg'],
-            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', '_1280x720', 'jpg']
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_SMALL, 'jpg'],
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_LARGE, 'jpg'],
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_POSTER, 'jpg'],
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg']
         ]
         response = self._path_request(paths=paths)
         return self._process_response(


### PR DESCRIPTION
This fixes the wrong usage of Netflix artwork in listitem art, fixing #134, #287, #325 and #340. It also adds support for clearlogos.

Quality of posters is reasonable, but not perfect. I wasn't able to determine a larger size than 342x684, because Netflix doesn't let you query for all available sizes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
