### PR TITLE
Permit to retrieve continueWatching list by name (or type)

### DIFF
--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -427,7 +427,7 @@ class Navigation(object):
         user_data = self._check_response(self.call_netflix_service({
             'method': 'get_user_data'}))
         if user_data:
-            user_list = ['queue', 'topTen', 'netflixOriginals',
+            user_list = ['queue', 'topTen', 'netflixOriginals', 'continueWatching',
                          'trendingNow', 'newRelease', 'popularTitles']
             if str(type) in user_list and video_list_id is None:
                 video_list_id = self.list_id_for_type(type)


### PR DESCRIPTION
Add type 'continueWatching' in user_list.
Because list_id can change between login or sessions, it's usefull to retrieve it by type (like queue, topTen, etc...), for persistent shortcut (ie : for use in widgets).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?