### PR TITLE
Add query parameter widget_display to suppress setting custom view modes

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -266,7 +266,8 @@ class KodiHelper(object):
 
         return xbmcplugin.endOfDirectory(handle=self.plugin_handle)
 
-    def build_main_menu_listing(self, video_list_ids, user_list_order, actions, build_url):
+    def build_main_menu_listing(self, video_list_ids, user_list_order, actions,
+                                build_url, widget_display=False):
         """
         Builds the video lists (my list, continue watching, etc.) Kodi screen
 
@@ -394,10 +395,13 @@ class KodiHelper(object):
         preselected_list_item = idx + 1 if self.get_main_menu_selection() == 'search' else preselected_list_item
         if preselected_list_item is not None:
             xbmc.executebuiltin('ActivateWindowAndFocus(%s, %s)' % (str(xbmcgui.Window(xbmcgui.getCurrentWindowId()).getFocusId()), str(preselected_list_item)))
-        self.set_custom_view(VIEW_FOLDER)
+        if not widget_display:
+            self.set_custom_view(VIEW_FOLDER)
         return True
 
-    def build_video_listing(self, video_list, actions, type, build_url, has_more=False, start=0, current_video_list_id=""):
+    def build_video_listing(self, video_list, actions, type, build_url,
+                            has_more=False, start=0, current_video_list_id="",
+                            widget_display=False):
         """
         Builds the video lists (my list, continue watching, etc.)
         contents Kodi screen
@@ -498,11 +502,12 @@ class KodiHelper(object):
 
         xbmcplugin.endOfDirectory(self.plugin_handle)
 
-        self.set_custom_view(view)
+        if not widget_display:
+            self.set_custom_view(view)
 
         return True
 
-    def build_video_listing_exported(self, content, build_url):
+    def build_video_listing_exported(self, content, build_url, widget_display=False):
         """Build list of exported movies / shows
 
         Parameters
@@ -587,10 +592,11 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             content=CONTENT_FOLDER)
         xbmcplugin.endOfDirectory(self.plugin_handle)
-        self.set_custom_view(VIEW_EXPORTED)
+        if not widget_display:
+            self.set_custom_view(VIEW_EXPORTED)
         return True
 
-    def build_search_result_folder(self, build_url, term):
+    def build_search_result_folder(self, build_url, term, widget_display=False):
         """Add search result folder
 
         Parameters
@@ -624,7 +630,8 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             content=CONTENT_FOLDER)
         xbmcplugin.endOfDirectory(self.plugin_handle)
-        self.set_custom_view(VIEW_FOLDER)
+        if not widget_display:
+            self.set_custom_view(VIEW_FOLDER)
         return url_rec
 
     def set_location(self, url, replace=False):
@@ -703,7 +710,8 @@ class KodiHelper(object):
         self.dialogs.show_no_search_results_notify()
         return xbmcplugin.endOfDirectory(self.plugin_handle)
 
-    def build_user_sub_listing(self, video_list_ids, type, action, build_url):
+    def build_user_sub_listing(self, video_list_ids, type, action, build_url,
+                               widget_display=False):
         """
         Builds the video lists screen for user subfolders
         (genres & recommendations)
@@ -746,10 +754,11 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             content=CONTENT_FOLDER)
         xbmcplugin.endOfDirectory(self.plugin_handle)
-        self.set_custom_view(VIEW_FOLDER)
+        if not widget_display:
+            self.set_custom_view(VIEW_FOLDER)
         return True
 
-    def build_season_listing(self, seasons_sorted, build_url):
+    def build_season_listing(self, seasons_sorted, build_url, widget_display=False):
         """Builds the season list screen for a show
 
         Parameters
@@ -805,10 +814,11 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             content=CONTENT_SEASON)
         xbmcplugin.endOfDirectory(self.plugin_handle)
-        self.set_custom_view(VIEW_SEASON)
+        if not widget_display:
+            self.set_custom_view(VIEW_SEASON)
         return True
 
-    def build_episode_listing(self, episodes_sorted, build_url):
+    def build_episode_listing(self, episodes_sorted, build_url, widget_display=False):
         """Builds the episode list screen for a season of a show
 
         Parameters
@@ -873,7 +883,8 @@ class KodiHelper(object):
             handle=self.plugin_handle,
             content=CONTENT_EPISODE)
         xbmcplugin.endOfDirectory(self.plugin_handle)
-        self.set_custom_view(VIEW_EPISODE)
+        if not widget_display:
+            self.set_custom_view(VIEW_EPISODE)
         return True
 
     def play_item(self, video_id, start_offset=-1, infoLabels={}):

--- a/resources/lib/Navigation.py
+++ b/resources/lib/Navigation.py
@@ -20,6 +20,7 @@ import urllib2
 from urlparse import parse_qsl, urlparse
 from datetime import datetime
 from collections import OrderedDict
+from distutils.util import strtobool
 
 import xbmc
 import resources.lib.NetflixSession as Netflix
@@ -79,6 +80,7 @@ class Navigation(object):
         action = params.get('action', None)
         p_type = params.get('type', None)
         p_type_not_search_export = p_type != 'search' and p_type != 'exported'
+        widget_display = bool(strtobool(params.get('widget_display', 'false')))
 
         # open foreign settings dialog
         if 'mode' in params.keys() and params['mode'] == 'openSettings':
@@ -119,7 +121,7 @@ class Navigation(object):
                     self.call_netflix_service({
                         'method': 'switch_profile',
                         'profile_id': profile_id})
-                    return self.show_video_lists()
+                    return self.show_video_lists(widget_display)
             return self.show_profiles()
         elif action == 'save_autologin':
             # save profile id and name to settings for autologin
@@ -130,7 +132,7 @@ class Navigation(object):
         elif action == 'video_lists':
             # list lists that contain other lists
             # (starting point with recommendations, search, etc.)
-            return self.show_video_lists()
+            return self.show_video_lists(widget_display=widget_display)
         elif action == 'video_list':
             # show a list of shows/movies
             type = None if 'type' not in params.keys() else params['type']
@@ -138,19 +140,22 @@ class Navigation(object):
             video_list = self.show_video_list(
                 video_list_id=params.get('video_list_id'),
                 type=type,
-                start=start)
+                start=start,
+                widget_display=widget_display)
             return video_list
         elif action == 'season_list':
             # list of seasons for a show
             seasons = self.show_seasons(
                 show_id=params.get('show_id'),
-                tvshowtitle=params.get('tvshowtitle'))
+                tvshowtitle=params.get('tvshowtitle'),
+                widget_display=widget_display)
             return seasons
         elif action == 'episode_list':
             # list of episodes for a season
             episode_list = self.show_episode_list(
                 season_id=params.get('season_id'),
-                tvshowtitle=params.get('tvshowtitle'))
+                tvshowtitle=params.get('tvshowtitle'),
+                widget_display=widget_display)
             return episode_list
         elif action == 'rating':
             return self.rate_on_netflix(video_id=params['id'])
@@ -202,7 +207,8 @@ class Navigation(object):
             return True
         elif action == 'user-items' and p_type_not_search_export:
             # display the lists (recommendations, genres, etc.)
-            return self.show_user_list(type=params['type'])
+            return self.show_user_list(type=params['type'],
+                                       widget_display=widget_display)
         elif action == 'play_video':
             # play a video, check for adult pin if needed
             adult_pin = None
@@ -229,7 +235,8 @@ class Navigation(object):
             if term:
                 result_folder = self.kodi_helper.build_search_result_folder(
                     build_url=self.build_url,
-                    term=term)
+                    term=term,
+                    widget_display=widget_display)
                 return self.kodi_helper.set_location(url=result_folder)
         elif action == 'search_result':
             return self.show_search_results(params.get('term'))
@@ -239,7 +246,8 @@ class Navigation(object):
             # list exported movies/shows
             exported = self.kodi_helper.build_video_listing_exported(
                 content=self.library.list_exported_media(),
-                build_url=self.build_url)
+                build_url=self.build_url,
+                widget_display=widget_display)
             return exported
         else:
             raise ValueError('Invalid paramstring: {0}!'.format(paramstring))
@@ -306,7 +314,7 @@ class Navigation(object):
         self.kodi_helper.dialogs.show_no_search_results_notify()
         return False
 
-    def show_user_list(self, type):
+    def show_user_list(self, type, widget_display=False):
         """
         List the users lists for shows/movies for
         recommendations/genres based on the given type
@@ -329,11 +337,12 @@ class Navigation(object):
                     video_list_ids=video_list_ids[type],
                     type=type,
                     action='video_list',
-                    build_url=self.build_url)
+                    build_url=self.build_url,
+                    widget_display=widget_display)
                 return sub_list
         return False
 
-    def show_episode_list(self, season_id, tvshowtitle):
+    def show_episode_list(self, season_id, tvshowtitle, widget_display=False):
         """Lists all episodes for a given season
 
         Parameters
@@ -363,11 +372,12 @@ class Navigation(object):
                 # list the episodes
                 episodes_list = self.kodi_helper.build_episode_listing(
                     episodes_sorted=episodes_sorted,
-                    build_url=self.build_url)
+                    build_url=self.build_url,
+                    widget_display=widget_display)
                 return episodes_list
         return False
 
-    def show_seasons(self, show_id, tvshowtitle):
+    def show_seasons(self, show_id, tvshowtitle, widget_display=False):
         """Lists all seasons for a given show
 
         Parameters
@@ -404,11 +414,13 @@ class Navigation(object):
                     season['tvshowtitle'] = tvshowtitle
                 season_list = self.kodi_helper.build_season_listing(
                     seasons_sorted=seasons_sorted,
-                    build_url=self.build_url)
+                    build_url=self.build_url,
+                    widget_display=widget_display)
                 return season_list
         return False
 
-    def show_video_list(self, video_list_id, type, start=0):
+    def show_video_list(self, video_list_id, type, start=0,
+                        widget_display=False):
         """List shows/movies based on the given video list id
 
         Parameters
@@ -460,11 +472,12 @@ class Navigation(object):
                 build_url=self.build_url,
                 has_more=has_more,
                 start=start,
-                current_video_list_id=video_list_id)
+                current_video_list_id=video_list_id,
+                widget_display=widget_display)
             return listing
         return False
 
-    def show_video_lists(self):
+    def show_video_lists(self, widget_display=False):
         """List the users video lists (recommendations, my list, etc.)"""
         user_data = self._check_response(self.call_netflix_service({
             'method': 'get_user_data'}))
@@ -492,7 +505,8 @@ class Navigation(object):
                     video_list_ids=video_list_ids,
                     user_list_order=user_list_order,
                     actions=actions,
-                    build_url=self.build_url)
+                    build_url=self.build_url,
+                    widget_display=widget_display)
                 return listing
         return False
 


### PR DESCRIPTION
This adds a query parameter `widget_display` that can optionally be appended to plugin calls, which, when `true`, suppresses the setting of custom view modes (even if enabled in the plugin settings).

It was driving me nuts, why my view modes seemingly changed at random, when I realized it was caused by the netflix widgets reloading in the background and overriding the viewmode of the currently active screen/container.

When adding anything from this plugin as a widget, simply append `&widget_display=true` to the call string and this behavior will be suppressed. This has no impact on the regular use of the addon whatsoever.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?