### PR TITLE
FIX: TypeError - byte strings and AES

### DIFF
--- a/resources/lib/MSLCrypto.py
+++ b/resources/lib/MSLCrypto.py
@@ -125,7 +125,7 @@ class MSLCrypto():
         plaintext = Padding.pad(data, 16)
         # Encrypt the text
         cipher = AES.new(self.encryption_key, AES.MODE_CBC, iv)
-        citext = cipher.encrypt(plaintext)
+        citext = cipher.encrypt(plaintext.encode("utf-8"))
         encryption_envelope['ciphertext'] = base64.standard_b64encode(citext)
 
         return encryption_envelope;


### PR DESCRIPTION
The AES encrypt function requires the string to be encoded with utf-8. Without doing so, I currently get the following error:
"TypeError: Only byte strings can be passed to C code"

This patch resolves.

## Types of changes

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [ X ] Have you followed the guidelines in our Contributing document?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [ X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ X ] Have you successfully ran tests with your changes locally?
