### PR TITLE
Fix for missing fanart images on non-netflix originals

### DIFF
--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -24,9 +24,10 @@ except:
 
 FETCH_VIDEO_REQUEST_COUNT = 26
 
-# Fanart: lower quality than 1080, but provides more variance
-# (1080 is usually the same as interestingMoment)
-ART_FANART_SIZE = '720'
+ART_FANART_SIZE = '1080'
+# Lower quality for episodes than 1080, because it provides more variance
+# (1080 is usually the same as interestingMoment for episodes)
+ART_FANART_SIZE_EPISODE = '720'
 ART_MOMENT_SIZE_SMALL = '_665x375'
 ART_MOMENT_SIZE_LARGE = '_1920x1080'
 ART_BOX_SIZE_POSTER = '_342x684'
@@ -1338,7 +1339,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = episode.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = episode.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])[0].get('url')
+        artwork = episode.get('BGImages', {}).get(ART_FANART_SIZE_EPISODE, {}).get('jpg', [{}])[0].get('url')
         logo = episode.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
@@ -1630,7 +1631,7 @@ class NetflixSession(object):
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_LARGE, 'jpg'],
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_POSTER, 'jpg'],
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
-            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'BGImages', ART_FANART_SIZE, 'jpg']
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'BGImages', ART_FANART_SIZE_EPISODE, 'jpg']
         ]
         response = self._path_request(paths=paths)
         return self._process_response(

--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -838,7 +838,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])[0].get('url')
+        artwork = next(iter(video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])), {}).get('url')
         logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
@@ -1193,7 +1193,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])[0].get('url')
+        artwork = next(iter(video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])), {}).get('url')
         logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
         return {
             season['summary']['id']: {
@@ -1339,7 +1339,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = episode.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = episode.get('BGImages', {}).get(ART_FANART_SIZE_EPISODE, {}).get('jpg', [{}])[0].get('url')
+        artwork = next(iter(episode.get('BGImages', {}).get(ART_FANART_SIZE_EPISODE, {}).get('jpg', [{}])), {}).get('url')
         logo = episode.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {

--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -24,13 +24,15 @@ except:
 
 FETCH_VIDEO_REQUEST_COUNT = 26
 
-ART_FANART_SIZE = '1080'
+# Fanart: lower quality than 1080, but provides more variance
+# (1080 is usually the same as interestingMoment)
+ART_FANART_SIZE = '720'
 ART_MOMENT_SIZE_SMALL = '_665x375'
 ART_MOMENT_SIZE_LARGE = '_1920x1080'
 ART_BOX_SIZE_POSTER = '_342x684'
 ART_BOX_SIZE_SMALL = '_665x375'
 ART_BOX_SIZE_LARGE = '_1920x1080'
-ART_LOGO_SIZE = '_400x90'
+ART_LOGO_SIZE = '_550x124'
 
 
 class NetflixSession(object):
@@ -835,7 +837,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', {}).get('url')
+        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])[0].get('url')
         logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
@@ -1190,7 +1192,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', {}).get('url')
+        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])[0].get('url')
         logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
         return {
             season['summary']['id']: {
@@ -1336,7 +1338,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = episode.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = episode.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', {}).get('url')
+        artwork = episode.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', [{}])[0].get('url')
         logo = episode.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {

--- a/resources/lib/NetflixSession.py
+++ b/resources/lib/NetflixSession.py
@@ -24,7 +24,7 @@ except:
 
 FETCH_VIDEO_REQUEST_COUNT = 26
 
-ART_BILLBOARD_SIZE = '_1920x1080'
+ART_FANART_SIZE = '1080'
 ART_MOMENT_SIZE_SMALL = '_665x375'
 ART_MOMENT_SIZE_LARGE = '_1920x1080'
 ART_BOX_SIZE_POSTER = '_342x684'
@@ -835,7 +835,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = video.get('artWorkByType', {}).get('BILLBOARD', {}).get(ART_BILLBOARD_SIZE, {}).get('jpg', {}).get('url')
+        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', {}).get('url')
         logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
@@ -1190,7 +1190,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = video.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = video.get('artWorkByType', {}).get('BILLBOARD', {}).get(ART_BILLBOARD_SIZE, {}).get('jpg', {}).get('url')
+        artwork = video.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', {}).get('url')
         logo = video.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
         return {
             season['summary']['id']: {
@@ -1336,7 +1336,7 @@ class NetflixSession(object):
         bx_big = boxarts.get(ART_BOX_SIZE_LARGE, {}).get('jpg', {}).get('url')
         bx_poster = boxarts.get(ART_BOX_SIZE_POSTER, {}).get('jpg', {}).get('url')
         moment = episode.get('interestingMoment', {}).get(ART_MOMENT_SIZE_LARGE, {}).get('jpg', {}).get('url')
-        artwork = episode.get('artWorkByType', {}).get('BILLBOARD', {}).get(ART_BILLBOARD_SIZE, {}).get('jpg', {}).get('url')
+        artwork = episode.get('BGImages', {}).get(ART_FANART_SIZE, {}).get('jpg', {}).get('url')
         logo = episode.get('bb2OGLogo', {}).get(ART_LOGO_SIZE, {}).get('png', {}).get('url')
 
         return {
@@ -1435,7 +1435,7 @@ class NetflixSession(object):
             item_path + item_titles + item_pagination + ['reference', 'storyarts', '_1632x873', 'jpg'],
             item_path + item_titles + item_pagination + ['reference', 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
             item_path + item_titles + item_pagination + ['reference', 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
-            item_path + item_titles + item_pagination + ['reference', 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg'],
+            item_path + item_titles + item_pagination + ['reference', 'BGImages', ART_FANART_SIZE, 'jpg'],
             item_path + item_titles + item_pagination + ['reference', 'cast', {'from': 0, 'to': 15}, ['id', 'name']],
             item_path + item_titles + item_pagination + ['reference', 'cast', 'summary'],
             item_path + item_titles + item_pagination + ['reference', 'genres', {'from': 0, 'to': 5}, ['id', 'name']],
@@ -1488,7 +1488,7 @@ class NetflixSession(object):
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'storyarts', '_1632x873', 'jpg'],
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
             ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
-            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg']
+            ['lists', [list_id], {'from': list_from, 'to': list_to}, "reference", 'BGImages', ART_FANART_SIZE, 'jpg']
         ]
 
         response = self._path_request(paths=paths)
@@ -1584,7 +1584,7 @@ class NetflixSession(object):
             ['videos', id, 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
             ['videos', id, 'interestingMoment', ART_MOMENT_SIZE_SMALL, 'jpg'],
             ['videos', id, 'interestingMoment', ART_MOMENT_SIZE_LARGE, 'jpg'],
-            ['videos', id, 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg']
+            ['videos', id, 'BGImages', ART_FANART_SIZE, 'jpg']
         ]
         response = self._path_request(paths=paths)
         return self._process_response(response=response, component='Seasons')
@@ -1628,7 +1628,7 @@ class NetflixSession(object):
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_LARGE, 'jpg'],
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'boxarts', ART_BOX_SIZE_POSTER, 'jpg'],
             ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'bb2OGLogo', ART_LOGO_SIZE, 'png'],
-            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'artWorkByType', 'BILLBOARD', ART_BILLBOARD_SIZE, 'jpg']
+            ['seasons', season_id, 'episodes', {'from': list_from, 'to': list_to}, 'BGImages', ART_FANART_SIZE, 'jpg']
         ]
         response = self._path_request(paths=paths)
         return self._process_response(


### PR DESCRIPTION
This fixes #408 by using another path evaluator property for retrieving fanart / backdrop images.

EDIT: Added some commits to fix an issue I initially missed and also provide more variance when viewing episodes. Incidentally, Netflix provides the same 1080p images for fanart and landscape boxart, which results in the same image being shown in the background and as the thumbnail for the currently selected item.
When using 720p resolution for episode fanart instead of 1080p, Netflix provides another image, that is different from the thumbnail. To introduce more variance into the artworks, I have opted for the lower quality fanart versions on episodes (does not apply to movies, shows and seasons, this is still full 1080p quality).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
