### PR TITLE
Fix #469. Get enabled setting for action manager as bool.

### DIFF
--- a/resources/lib/playback/__init__.py
+++ b/resources/lib/playback/__init__.py
@@ -154,7 +154,7 @@ class PlaybackActionManager(LoggingComponent):
         """
         if self._enabled is None:
             self.log('Loading enabled setting from store')
-            self._enabled = self.addon.getSetting(
+            self._enabled = self.addon.getSettingBool(
                 '{}_enabled'.format(self.__class__.__name__))
 
         return self._enabled


### PR DESCRIPTION
Fixes #469 by getting enabled setting for playback actions (skip intro, ...) as bool instead of string.