### PR TITLE
Fix autmatic intro skipping, improve remembering audio

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -885,7 +885,7 @@ class KodiHelper(object):
             self.set_custom_view(VIEW_EPISODE)
         return True
 
-    def play_item(self, video_id, start_offset=-1, infoLabels={}, timeline_markers={}):
+    def play_item(self, video_id, start_offset=-1, infoLabels={}, tvshow_video_id=None, timeline_markers={}):
         """Plays a video
 
         Parameters
@@ -953,6 +953,9 @@ class KodiHelper(object):
         play_item.setInfo('video', infoLabels)
 
         signal_data = {'timeline_markers': timeline_markers}
+
+        if tvshow_video_id is not None:
+            signal_data.update({'tvshow_video_id': tvshow_video_id})
 
         # check for content in kodi db
         if str(infoLabels) != 'None':

--- a/resources/lib/playback/section_skipping.py
+++ b/resources/lib/playback/section_skipping.py
@@ -59,7 +59,8 @@ class SectionSkipper(PlaybackActionManager):
         self.log('Auto-skipping {}'.format(section))
         player = xbmc.Player()
         xbmcgui.Dialog().notification(
-            'Netflix', '{}...'.format(label), xbmcgui.NOTIFICATION_INFO, 5000)
+            'Netflix', '{}...'.format(label.encode('utf-8')),
+            xbmcgui.NOTIFICATION_INFO, 5000)
         if self.pause_on_skip:
             player.pause()
             xbmc.sleep(1000)  # give kodi the chance to execute

--- a/resources/lib/playback/stream_continuity.py
+++ b/resources/lib/playback/stream_continuity.py
@@ -52,7 +52,7 @@ class StreamContinuityManager(PlaybackActionManager):
         self.did_restore = False
         # let this throw a KeyError to disable this instance if the playback is
         # not a TV show
-        self.current_show = data['dbinfo']['tvshowid']
+        self.current_show = data['tvshow_video_id']
 
     def _on_playback_started(self, player_state):
         xbmc.sleep(1000)


### PR DESCRIPTION
Fixes #463.

Adds ability to remember audio and subtitle settings for **all** shows, not just those in the local library.
Because it's no longer tied to the DBID but rather the Netflix video_id of the tv show, settings that are already saved are no longer applied. You must save these once again.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?
