### PR TITLE
Fix failsave response if image is missing

### DIFF
--- a/resources/lib/Library.py
+++ b/resources/lib/Library.py
@@ -851,4 +851,4 @@ class Library(object):
         file = os.path.join(self.imagecache_path, imgfile)
         if xbmcvfs.exists(file):
             return file
-        return self.nx_common.default_fanart
+        return ""


### PR DESCRIPTION
Old response caused a script fail and opening exported from main was not possible.
Current solutions shows netflix image if fanart is missing.
Only quick fix until caphm will finalize his big commit set for 0.14