### PR TITLE
fix: exception breaking reproductions when playcount missing

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -983,7 +983,7 @@ class KodiHelper(object):
                     'dbinfo': {
                         'dbid': details[0]['dbid'],
                         'dbtype': details[0]['mediatype'],
-                        'playcount': details[0]['playcount']}})
+                        'playcount': details[0].get('playcount',0)}})
                 if infoLabels['mediatype'] == 'episode':
                     signal_data['dbinfo'].update({'tvshowid': id[0]})
 


### PR DESCRIPTION
## Types of changes
- [*] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [*] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [*] Have you followed the guidelines in our Contributing document?
* [*] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [*] Have you added an explanation of what your changes do and why you'd like us to include them?
* [*] Have you successfully ran tests with your changes locally?

## Screenshots (if appropriate):

Sometimes the netflix plugin marks an episode as not seen and deletes the playcount field. This makes watching the episode or film impossible as when creating the infos object this field is accessed. Here is an example exception.
```
ERROR: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                             - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                            Error Type: <type 'exceptions.KeyError'>
                                            Error Contents: 'playcount'
                                            Traceback (most recent call last):
                                              File "/storage/.kodi/addons/plugin.video.netflix/addon.py", line 33, in <module>
                                                NAVIGATION.router(paramstring=REQUEST_PARAMS)
                                              File "/storage/.kodi/addons/plugin.video.netflix/resources/lib/utils.py", line 60, in wrapped
                                                result = func(*args, **kwargs)
                                              File "/storage/.kodi/addons/plugin.video.netflix/resources/lib/Navigation.py", line 253, in router
                                                infoLabels=params.get('infoLabels', {}))
                                              File "/storage/.kodi/addons/plugin.video.netflix/resources/lib/utils.py", line 60, in wrapped
                                                result = func(*args, **kwargs)
                                              File "/storage/.kodi/addons/plugin.video.netflix/resources/lib/Navigation.py", line 313, in play_video
                                                timeline_markers=self._get_timeline_markers(metadata))
                                              File "/storage/.kodi/addons/plugin.video.netflix/resources/lib/KodiHelper.py", line 986, in play_item
                                                'playcount': details[0]['playcount']}})
                                            KeyError: 'playcount'
                                            -->End of Python script error report<--
```

Instead we use the dictionary get method so that we can fall back to 0 when the attribute is absent.