### PR TITLE
Fix playback when OMXPlayer is enabled

### DIFF
--- a/resources/lib/KodiHelper.py
+++ b/resources/lib/KodiHelper.py
@@ -925,6 +925,10 @@ class KodiHelper(object):
         play_item = xbmcgui.ListItem(path=msl_manifest_url)
         play_item.setContentLookup(False)
         play_item.setMimeType('application/dash+xml')
+        # NOTE: This is required to avoid black/gibberish playback on Raspberry Pi
+        play_item.setProperty(
+            key='videoplayer.useomxplayer',
+            value='false')
         play_item.setProperty(
             key=is_helper.inputstream_addon + '.stream_headers',
             value='user-agent=' + get_user_agent())


### PR DESCRIPTION
A lot of users on Raspberry Pi are affected by a playback issue when
OMXPlayer is enabled. On Raspberry Pi OMXPlayer improves playback of
various streams, but it totally breaks Netflix playback.

This fixes reports on #237, #274, #286, #319, #656 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the [**CONTRIBUTING**](Contributing.md) document.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

## Screenshots (if appropriate):

[You can erase any parts of this template not applicable to your Pull Request.]
