### PR TITLE
Add Atmos capability

### DIFF
--- a/resources/lib/MSLv2.py
+++ b/resources/lib/MSLv2.py
@@ -212,6 +212,7 @@ class MSL(object):
         if dolby:
             profiles.append('ddplus-2.0-dash')
             profiles.append('ddplus-5.1-dash')
+            profiles.append('ddplus-atmos-dash')
 
         manifest_request_data["params"]["profiles"] = profiles
         #print manifest_request_data
@@ -461,7 +462,8 @@ class MSL(object):
                 #self.nx_common.log(msg=stream)
                 is_dplus2 = stream['content_profile'] == 'ddplus-2.0-dash'
                 is_dplus5 = stream['content_profile'] == 'ddplus-5.1-dash'
-                if is_dplus2 or is_dplus5:
+                is_dplus_atmos = stream['content_profile'] == 'ddplus-atmos-dash'
+                if is_dplus2 or is_dplus5 or is_dplus_atmos:
                     codec = 'ec-3'
                 #self.nx_common.log(msg='codec is: ' + codec)
                 rep = ET.SubElement(


### PR DESCRIPTION
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

This adds the ability to select Atmos streams. As long as your Kodi setup allows EAC3/DD+ passthrough, you will get the Atmos bits passed through to your receiver.

I have verified with my receiver/soundbar (Samsung K950) and the Atmos indicator lights up!

It seems to also allow selecting the new, higher quality audio streams (see https://medium.com/netflix-techblog/engineering-a-studio-quality-experience-with-high-quality-audio-at-netflix-eaa0b6145f32).

This was verified on a Xiaomi Mibox 3.