### PR TITLE
Credentials unit tests

### DIFF
--- a/resources/lib/NetflixCredentials.py
+++ b/resources/lib/NetflixCredentials.py
@@ -42,7 +42,7 @@ class NetflixCredentials(object):
             The users stored account data
         """
         # if everything is fine, we decode the values
-        if (email and '' != email) or (password and '' != password):
+        if (email and '' != email) and (password and '' != password):
             return {
                 'email': self.decode(enc=email),
                 'password': self.decode(enc=password)

--- a/resources/lib/NetflixCredentials.py
+++ b/resources/lib/NetflixCredentials.py
@@ -21,7 +21,7 @@ class NetflixCredentials(object):
             The users stored account data
         """
         # if everything is fine, we encode the values
-        if '' != email or '' != password:
+        if '' != email and '' != password:
             return {
                 'email': self.encode(raw=email),
                 'password': self.encode(raw=password)

--- a/resources/test/test_NetflixCredentials.py
+++ b/resources/test/test_NetflixCredentials.py
@@ -11,7 +11,7 @@ from resources.lib.NetflixCredentials import NetflixCredentials
 
 class NetflixCredentialsTestCase(unittest.TestCase):
 
-    def test_can_encode_and_decode_email_and_pass(self):
+    def test_can_encode_and_decode_email_and_password(self):
         email = 'tom'
         password = 'rubbish password'
         cred = NetflixCredentials()
@@ -50,4 +50,29 @@ class NetflixCredentialsTestCase(unittest.TestCase):
         self.assertEqual('', encoded['email'])
         self.assertEqual('', encoded['password'])
 
+    def test_empty_email_will_not_decode(self):
+        cred = NetflixCredentials()
+        email = ''
+        password = cred.encode('rubbish password')
+        decoded = cred.decode_credentials(email, password)
 
+        self.assertEqual('', decoded['email'])
+        self.assertEqual('', decoded['password'])
+
+    def test_empty_password_will_not_decode(self):
+        cred = NetflixCredentials()
+        email = cred.encode('tom')
+        password = ''
+        decoded = cred.decode_credentials(email, password)
+
+        self.assertEqual('', decoded['email'])
+        self.assertEqual('', decoded['password'])
+
+    def test_empty_email_and_password_will_not_decode(self):
+        cred = NetflixCredentials()
+        email = ''
+        password = ''
+        decoded = cred.decode_credentials(email, password)
+
+        self.assertEqual('', decoded['email'])
+        self.assertEqual('', decoded['password'])

--- a/resources/test/test_NetflixCredentials.py
+++ b/resources/test/test_NetflixCredentials.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# Module: NetflixCredentials
+# Author: tomjshore
+# Created on: 20.08.2019
+# License: MIT https://goo.gl/5bMj3H
+
+"""Testing for NetflixCredentials"""
+
+import unittest
+from resources.lib.NetflixCredentials import NetflixCredentials
+
+class NetflixCredentialsTestCase(unittest.TestCase):
+
+    def test_can_encode_and_decode_email_and_pass(self):
+        email = 'tom'
+        password = 'rubbish password'
+        cred = NetflixCredentials()
+        encoded = cred.encode_credentials(email, password)
+        decoded = cred.decode_credentials(encoded['email'], encoded['password'])
+
+        self.assertEqual(email, decoded['email'])
+        self.assertEqual(password, decoded['password'])
+        self.assertNotEqual(email, encoded['email'])
+        self.assertNotEqual(password, encoded['password'])

--- a/resources/test/test_NetflixCredentials.py
+++ b/resources/test/test_NetflixCredentials.py
@@ -22,3 +22,32 @@ class NetflixCredentialsTestCase(unittest.TestCase):
         self.assertEqual(password, decoded['password'])
         self.assertNotEqual(email, encoded['email'])
         self.assertNotEqual(password, encoded['password'])
+
+    def test_empty_email_will_not_encode(self):
+        email = ''
+        password = 'rubbish password'
+        cred = NetflixCredentials()
+        encoded = cred.encode_credentials(email, password)
+
+        self.assertEqual('', encoded['email'])
+        self.assertEqual('', encoded['password'])
+
+    def test_empty_password_will_not_encode(self):
+        email = 'tom'
+        password = ''
+        cred = NetflixCredentials()
+        encoded = cred.encode_credentials(email, password)
+
+        self.assertEqual('', encoded['email'])
+        self.assertEqual('', encoded['password'])
+
+    def test_empty_email_and_password_will_not_encode(self):
+        email = ''
+        password = ''
+        cred = NetflixCredentials()
+        encoded = cred.encode_credentials(email, password)
+
+        self.assertEqual('', encoded['email'])
+        self.assertEqual('', encoded['password'])
+
+


### PR DESCRIPTION
## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] I have read the [**CONTRIBUTING**](Contributing.md) document.

This is to add unit tests to the NetflixCredentials class.  The only change to "real" code was to change the if statements on string validation so the when encoding/decodeing it will return empty string if email or password is empty (this seems to be the intention viewing the code comments).
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes to Core Features:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

